### PR TITLE
Remove debug console output and improve RPM lights logic

### DIFF
--- a/HaddySimHub/Displays/ETS/Display.cs
+++ b/HaddySimHub/Displays/ETS/Display.cs
@@ -38,17 +38,6 @@ internal sealed class Display() : DisplayBase<SCSTelemetry>()
             _fuelAverageConsumption = fuelAverageConsumption;
         }
 
-        Console.Clear();
-        Console.WriteLine($"HShifterSlot: {data.TruckValues.CurrentValues.MotorValues.GearValues.HShifterSlot}");
-        Console.WriteLine($"Selected: {data.TruckValues.CurrentValues.MotorValues.GearValues.Selected}");
-        Console.WriteLine($"SlotGear: {data.TruckValues.ConstantsValues.MotorValues.SlotGear}");
-        Console.WriteLine($"ShifterTypeValue: {data.TruckValues.ConstantsValues.MotorValues.ShifterTypeValue}");
-        Console.WriteLine($"EngineRpmMax: {data.TruckValues.ConstantsValues.MotorValues.EngineRpmMax}");
-        Console.WriteLine($"ForwardGearCount: {data.TruckValues.ConstantsValues.MotorValues.ForwardGearCount}");
-        Console.WriteLine($"ReverseGearCount: {data.TruckValues.ConstantsValues.MotorValues.ReverseGearCount}");
-        Console.WriteLine($"SelectorCount: {data.TruckValues.ConstantsValues.MotorValues.SelectorCount}");
-        Console.WriteLine($"SlotHandlePosition: {data.TruckValues.ConstantsValues.MotorValues.SlotHandlePosition}");
-
         string gear = string.Empty;
         int selectedGear = data.TruckValues.CurrentValues.MotorValues.GearValues.Selected;
         if (selectedGear == 0)

--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -53,7 +53,7 @@ internal sealed class Display() : DisplayBase<DataSample>()
         }
 
         var timingEntries = new List<TimingEntry>();
-
+        string CarScreenName = string.Empty;
         foreach (var driver in sessionData.DriverInfo.CompetingDrivers)
         {
             var carIdx = (int)driver.CarIdx;
@@ -88,8 +88,7 @@ internal sealed class Display() : DisplayBase<DataSample>()
 
             if (carIdx == telemetry.PlayerCarIdx)
             {
-                Console.WriteLine($"CarScreenName: {driver.CarScreenName}");
-                Console.WriteLine($"CarScreenNameShort: {driver.CarScreenNameShort}");
+                CarScreenName = driver.CarScreenName;
             }
 
             // The license string is in the format R 02.0 remove the zero after the space
@@ -128,13 +127,7 @@ internal sealed class Display() : DisplayBase<DataSample>()
             }
         }
 
-        // Console.Clear();
         var orderedEntries = timingEntries.OrderByDescending(e => e.TimeToPlayer).ToArray();
-
-        // foreach (var entry in orderedEntries)
-        // {
-        //     Console.WriteLine($"#{entry.CarNumber} {entry.DriverName} - {entry.License} - {entry.LicenseColor} - {entry.IRating} - {entry.Laps} - {entry.LapCompletedPct}% - {entry.TimeToPlayer}");
-        // }
 
         var displayUpdate = new RaceData
         {
@@ -155,7 +148,7 @@ internal sealed class Display() : DisplayBase<DataSample>()
             BestLapTimeDelta = telemetry.LapBestLapTime <= 0 ? 0 : telemetry.LapDeltaToSessionBestLap,
             Gear = telemetry.Gear == -1 ? "R" : telemetry.Gear == 0 ? "N" : telemetry.Gear.ToString(),
             Rpm = (int)telemetry.RPM,
-            RpmLights = [.. GenerateRpmLights()],
+            RpmLights = [.. GenerateRpmLights(CarScreenName)],
             RpmMax = 7000,
             Speed = (int)Math.Round(telemetry.Speed * 3.6),
             BrakePct = (int)Math.Round(telemetry.Brake * 100, 0),
@@ -168,11 +161,6 @@ internal sealed class Display() : DisplayBase<DataSample>()
             PitLimiterOn = telemetry.EngineWarnings.HasFlag(EngineWarnings.PitSpeedLimiter),
             TimingEntries = orderedEntries,
         };
-
-        if (displayUpdate.Rpm == 0)
-        {
-            Console.WriteLine("RPM is 0, likely not in a car or telemetry data is not available.");
-        }
 
         return new DisplayUpdate { Type = DisplayType.RaceDashboard, Data = displayUpdate };
     }
@@ -224,17 +212,21 @@ internal sealed class Display() : DisplayBase<DataSample>()
         return flag;
     }
 
-    public static RpmLight[] GenerateRpmLights()
+    public static RpmLight[] GenerateRpmLights(string carName)
     {
-        // Based on iRacing's F4 car RPM lights (https://s100.iracing.com/wp-content/uploads/2023/10/FIA-F4-Manual-V2.pdf)
-        return
-        [
-            new RpmLight { Rpm = 6300, Color = "Green" },
-            new RpmLight { Rpm = 6500, Color = "Green" },
-            new RpmLight { Rpm = 6600, Color = "Green" },
-            new RpmLight { Rpm = 6700, Color = "Green" },
-            new RpmLight { Rpm = 6800, Color = "Red" },
-            new RpmLight { Rpm = 6900, Color = "Red" }
-        ];
+        if (carName == "FIA F4")
+        {
+            return
+            [
+                new RpmLight { Rpm = 6300, Color = "Green" },
+                new RpmLight { Rpm = 6500, Color = "Green" },
+                new RpmLight { Rpm = 6600, Color = "Green" },
+                new RpmLight { Rpm = 6700, Color = "Green" },
+                new RpmLight { Rpm = 6800, Color = "Red" },
+                new RpmLight { Rpm = 6900, Color = "Red" }
+            ];
+        }
+
+        return [];
     }
 }


### PR DESCRIPTION
Removed unnecessary Console.WriteLine and Console.Clear debug statements from ETS and iRacing display code. Updated iRacing Display to pass car name to GenerateRpmLights, allowing for car-specific RPM light configurations, currently supporting FIA F4.