### PR TITLE
Remove unnecessary nullish coalescing for rpmLights

### DIFF
--- a/ClientApp/src/app/app.component.spec.ts
+++ b/ClientApp/src/app/app.component.spec.ts
@@ -58,7 +58,7 @@ describe('AppComponent tests', () => {
 
   it('should show the rally display when rally data is available', async () => {
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, AppComponentHarness);
-    mockSignalRService.displayData.set({ type: DisplayType.RallyDashboard, data: {} as RallyData, page: 1 } as DisplayUpdate);
+    mockSignalRService.displayData.set({ type: DisplayType.RallyDashboard, data: { rpmLights: []} as unknown as RallyData, page: 1 } as DisplayUpdate);
 
     expect(await harness.isTruckDisplayVisible()).toBeFalse();
     expect(await harness.isRaceDisplayVisible()).toBeFalse();

--- a/ClientApp/src/app/displays/race-display/dashboard-page.component.html
+++ b/ClientApp/src/app/displays/race-display/dashboard-page.component.html
@@ -37,7 +37,7 @@
       </div>
     </div>
     <div class=" group-border border-yellow speedometer">
-      <app-rpm-lights [rpm]="data().rpm" [rpmMax]="data().rpmMax" [biDirectional]="false" [lights]="data().rpmLights ?? []"  />
+      <app-rpm-lights [rpm]="data().rpm" [rpmMax]="data().rpmMax" [biDirectional]="false" [lights]="data().rpmLights"  />
       <app-speedometer [rpm]="data().rpm" [gear]="data().gear" [speed]="data().speed" />
     </div>
     <div class="group-border border-blue">

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.html
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.html
@@ -7,7 +7,7 @@
     <div>{{data().distanceTravelled}} m</div>
   </div>
   <div class="group-border border-yellow speedometer">
-    <app-rpm-lights [rpm]="data().rpm" [rpmMax]="data().rpmMax" [biDirectional]="true" [lights]="data().rpmLights ?? []"  />
+    <app-rpm-lights [rpm]="data().rpm" [rpmMax]="data().rpmMax" [biDirectional]="true" [lights]="data().rpmLights"  />
     <app-speedometer [rpm]="data().rpm" [gear]="data().gear" [speed]="data().speed" />
   </div>
   <div class="group-border border-blue">


### PR DESCRIPTION
Replaced '[lights]=data().rpmLights ?? []' with '[lights]=data().rpmLights' in dashboard and rally display components to simplify input binding and avoid redundant defaulting.
