### PR TITLE
Handle oneLapToGreen session flag in display

### DIFF
--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -204,6 +204,12 @@ internal sealed class Display() : DisplayBase<DataSample>()
                 sessionFlags &= ~SessionFlags.fiveToGo;
                 flag = "green";
             }
+
+            if (sessionFlags.HasFlag(SessionFlags.oneLapToGreen))
+            {
+                sessionFlags &= ~SessionFlags.oneLapToGreen;
+                flag = "green";
+            }
         }
 
         if (flag is null)


### PR DESCRIPTION
Added logic to clear the oneLapToGreen session flag and set the display flag to green when detected. This ensures proper flag handling for race session transitions.
