### PR TITLE
Refine lap ahead/behind calculation logic

### DIFF
--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -124,8 +124,15 @@ internal sealed class Display() : DisplayBase<DataSample>()
                 {
                     var lapDiff = e.Laps - playerEntry.Laps;
                     var positionInLap = e.LapCompletedPct - playerEntry.LapCompletedPct;
-                    e.IsLapAhead = lapDiff > 0 || (lapDiff == 0 && positionInLap > 80);
-                    e.IsLapBehind = lapDiff < 0 || (lapDiff == 0 && positionInLap < -80);
+                    
+                    // Calculate total position including laps
+                    var totalPosition = (lapDiff * 100) + positionInLap;
+                    
+                    // Car is ahead if total position is positive
+                    e.IsLapAhead = totalPosition > 0;
+                    
+                    // Car is behind if total position is negative
+                    e.IsLapBehind = totalPosition < 0;
                 });
             }
         }


### PR DESCRIPTION
Updated the logic for determining if a car is ahead or behind by calculating a total position value based on lap difference and lap completion percentage, improving accuracy over the previous threshold-based approach.