### PR TITLE
Fix lap time display and best lap time calculation

### DIFF
--- a/ClientApp/src/app/shared/time/time.pipe.ts
+++ b/ClientApp/src/app/shared/time/time.pipe.ts
@@ -15,6 +15,10 @@ export class TimePipe implements PipeTransform {
     const paddedMinutes = minutes.toString().padStart(2, '0');
     const paddedSeconds = secs.toString().padStart(2, '0');
 
+    if (seconds === 168 * 3600) {
+      return '--:--:--';
+    }
+
     if (hours === 0) {
       return `${sign}${paddedMinutes}:${paddedSeconds}`;
     }

--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -154,7 +154,7 @@ internal sealed class Display() : DisplayBase<DataSample>()
             CurrentLapTime = telemetry.LapCurrentLapTime,
             LastLapTime = Math.Max(telemetry.LapLastLapTime, 0),
             LastLapTimeDelta = telemetry.LapLastLapTime <= 0 ? 0 : telemetry.LapDeltaToSessionLastlLap,
-            BestLapTime = Math.Max(telemetry.LapDeltaToSessionBestLap, 0),
+            BestLapTime = Math.Max(telemetry.LapBestLapTime, 0),
             BestLapTimeDelta = telemetry.LapDeltaToSessionBestLap <= 0 ? 0 : telemetry.LapDeltaToSessionBestLap,
             Gear = telemetry.Gear == -1 ? "R" : telemetry.Gear == 0 ? "N" : telemetry.Gear.ToString(),
             Rpm = (int)telemetry.RPM,


### PR DESCRIPTION
TimePipe now returns '--:--:--' for a sentinel value of 168 hours, improving display for undefined times. In Display.cs, best lap time is now correctly set using LapBestLapTime instead of LapDeltaToSessionBestLap.