### PR TITLE
Refactor component tests to use inputBinding

### DIFF
--- a/ClientApp/src/app/displays/race-display/track-positions.component.spec.ts
+++ b/ClientApp/src/app/displays/race-display/track-positions.component.spec.ts
@@ -2,12 +2,12 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { TrackPositionsComponent } from './track-positions.component';
 import { TrackPositionsComponentHarness } from './track-positions.component.harness';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { inputBinding, provideZonelessChangeDetection } from '@angular/core';
 import { TimingEntry } from './race-data';
 
 describe('TrackPositionsComponent tests', () => {
-  let fixture: ComponentFixture<TrackPositionsTestHostComponent>;
-  let component: TrackPositionsTestHostComponent;
+  let fixture: ComponentFixture<TrackPositionsComponent>;
+  let positions: TimingEntry[];
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -16,12 +16,17 @@ describe('TrackPositionsComponent tests', () => {
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(TrackPositionsTestHostComponent);
-    component = fixture.componentInstance;
+    positions = [];
+
+    fixture = TestBed.createComponent(TrackPositionsComponent, {
+      bindings: [
+        inputBinding('positions', () => positions),
+      ],
+    });
   });
 
   it('locates the track position elements correctly', async () => {
-    component.positions = [
+    positions = [
       {
         lapCompletedPct: 0,
         isInPits: true,
@@ -38,11 +43,3 @@ describe('TrackPositionsComponent tests', () => {
     expect(items).toEqual([{ style: 'left: 0%;' }, { style: 'left: 10%;' }]);
   });
 });
-
-@Component({
-  template: '<app-track-positions [positions]="positions" />',
-  imports: [TrackPositionsComponent],
-})
-class TrackPositionsTestHostComponent {
-  public positions: TimingEntry[] = [];
-}

--- a/ClientApp/src/app/displays/truck-display/waypoint.component.spec.ts
+++ b/ClientApp/src/app/displays/truck-display/waypoint.component.spec.ts
@@ -1,12 +1,13 @@
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { inputBinding, provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { WaypointComponentHarness } from './waypoint.component.harness';
 import { WaypointComponent } from './waypoint.component';
 
 describe('WaypointComponent tests', () => {
-  let fixture: ComponentFixture<WaypointTestHostComponent>;
-  let component: WaypointTestHostComponent;
+  let fixture: ComponentFixture<WaypointComponent>;
+  let city: string;
+  let company: string;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,38 +16,36 @@ describe('WaypointComponent tests', () => {
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(WaypointTestHostComponent);
-    component = fixture.componentInstance;
+    city = '';
+    company = '';
+
+    fixture = TestBed.createComponent(WaypointComponent, {
+      bindings: [
+        inputBinding('city', () => city),
+        inputBinding('company', () => company),
+      ],
+    });
   });
 
   it('When city is not set a placeholder is shown', async () => {
-    component.city = '';
+    city = '';
 
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, WaypointComponentHarness);
     expect(await harness.getDescription()).toEqual('-');
   });
 
   it('City is displayed when company is not set', async () => {
-    component.city = 'Berlin';
+    city = 'Berlin';
 
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, WaypointComponentHarness);
     expect(await harness.getDescription()).toEqual('Berlin');
   });
 
   it('City and company are displayed both are set', async () => {
-    component.city = 'Berlin';
-    component.company = 'Company B';
+    city = 'Berlin';
+    company = 'Company B';
 
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, WaypointComponentHarness);
     expect(await harness.getDescription()).toEqual('Berlin (Company B)');
   });
 });
-
-@Component({
-  template: `<app-waypoint [city]="city" [company]="company" />`,
-  imports: [WaypointComponent],
-})
-class WaypointTestHostComponent {
-  public city = '';
-  public company = '';
-}

--- a/ClientApp/src/app/shared/speedometer/speedometer.component.spec.ts
+++ b/ClientApp/src/app/shared/speedometer/speedometer.component.spec.ts
@@ -2,11 +2,13 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { SpeedometerComponent } from './speedometer.component';
 import { TestbedHarnessEnvironment } from '@angular/cdk/testing/testbed';
 import { SpeedometerComponentHarness } from './speedometer.component.harness';
-import { Component, provideZonelessChangeDetection } from '@angular/core';
+import { inputBinding, provideZonelessChangeDetection } from '@angular/core';
 
 describe('SpeedometerComponent tests', () => {
-  let fixture: ComponentFixture<SpeedometerTestHostComponent>;
-  let component: SpeedometerTestHostComponent;
+  let fixture: ComponentFixture<SpeedometerComponent>;
+  let rpm: number;
+  let speed: number;
+  let gear: number;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -15,25 +17,24 @@ describe('SpeedometerComponent tests', () => {
       ],
     }).compileComponents();
 
-    fixture = TestBed.createComponent(SpeedometerTestHostComponent);
-    component = fixture.componentInstance;
+    rpm = 0;
+    speed = 0;
+    gear = 0;
+
+    fixture = TestBed.createComponent(SpeedometerComponent, {
+      bindings: [
+        inputBinding('rpm', () => rpm),
+        inputBinding('speed', () => speed),
+        inputBinding('gear', () => gear),
+      ],
+    });
   });
 
   it('should display the current gear', async () => {
-    component.gear = 2;
+    gear = 2;
 
     const harness = await TestbedHarnessEnvironment.harnessForFixture(fixture, SpeedometerComponentHarness);
 
     expect(await harness.getGear()).toEqual('2');
   });
 });
-
-@Component({
-  template: `<app-speedometer [rpm]="rpm" [speed]="speed" [gear]="gear" />`,
-  imports: [SpeedometerComponent],
-})
-class SpeedometerTestHostComponent {
-  public rpm = 0;
-  public speed = 0;
-  public gear = 0;
-}


### PR DESCRIPTION
Updated test specs for TrackPositionsComponent, WaypointComponent, and SpeedometerComponent to use Angular's inputBinding for setting inputs directly, removing test host components for cleaner and more direct testing.
