### PR TITLE
Move lap status classes to name-class-row container

### DIFF
--- a/ClientApp/src/app/displays/race-display/dashboard-page.component.spec.ts
+++ b/ClientApp/src/app/displays/race-display/dashboard-page.component.spec.ts
@@ -200,11 +200,11 @@ describe('Dashboard page component tests', () => {
         ]});
 
       expect(await harness.getElementText('#driverAheadInfo .driver-name')).toEqual('Enrique Bernoldi');
-      expect(await harness.elementHasClass('#driverAheadInfo .driver-name', 'lap-behind')).toBeTrue();
-      expect(await harness.elementHasClass('#driverAheadInfo .driver-name', 'lap-ahead')).toBeFalse();
+      expect(await harness.elementHasClass('#driverAheadInfo .name-class-row', 'lap-behind')).toBeTrue();
+      expect(await harness.elementHasClass('#driverAheadInfo .name-class-row', 'lap-ahead')).toBeFalse();
       expect(await harness.getElementText('#driverBehindInfo .driver-name')).toEqual('David Coulthard');
-      expect(await harness.elementHasClass('#driverBehindInfo .driver-name', 'lap-behind')).toBeFalse();
-      expect(await harness.elementHasClass('#driverBehindInfo .driver-name', 'lap-ahead')).toBeTrue();
+      expect(await harness.elementHasClass('#driverBehindInfo .name-class-row', 'lap-behind')).toBeFalse();
+      expect(await harness.elementHasClass('#driverBehindInfo .name-class-row', 'lap-ahead')).toBeTrue();
     });
   });
 

--- a/ClientApp/src/app/displays/race-display/opponent-delta.component.html
+++ b/ClientApp/src/app/displays/race-display/opponent-delta.component.html
@@ -1,11 +1,12 @@
 <div class="opponent-delta group-border border-blue">
   <label>{{caption()}}</label>
   <div>
-    <div class="name-class-row" [class.hidden]="!driverInfo()">
-      <div class="driver-name"
-        [class.lap-ahead]="driverInfo()?.isLapAhead"
-        [class.lap-behind]="driverInfo()?.isLapBehind"
-        [class.in-pits]="driverInfo()?.isInPits">{{driverInfo()?.totalPosition | number:'1.1-1' }} {{driverInfo()?.driverName}}</div>
+    <div class="name-class-row"
+      [class.hidden]="!driverInfo()"
+      [class.lap-ahead]="driverInfo()?.isLapAhead"
+      [class.lap-behind]="driverInfo()?.isLapBehind"
+      [class.in-pits]="driverInfo()?.isInPits">
+      <div class="driver-name">{{driverInfo()?.totalPosition | number:'1.1-1' }} {{driverInfo()?.driverName}}</div>
       <div class="delta-time">{{ deltaTime() | deltatime:1}}</div>
     </div>
   </div>

--- a/ClientApp/src/app/displays/race-display/opponent-delta.component.scss
+++ b/ClientApp/src/app/displays/race-display/opponent-delta.component.scss
@@ -2,6 +2,18 @@
     display: grid;
     grid-template-columns: auto 1fr;
     align-items: center;
+
+    &.lap-ahead {
+        color: red;
+    }
+
+    &.lap-behind {
+        color: blue;
+    }
+
+    &.in-pits {
+        color: gray;
+    }
 }
 
 .opponent-delta {
@@ -18,18 +30,6 @@
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-
-    &.lap-ahead {
-        color: red;
-    }
-
-    &.lap-behind {
-        color: blue;
-    }
-
-    &.in-pits {
-        color: gray;
-    }
 }
 
 .delta-time {


### PR DESCRIPTION
Shifted lap-ahead, lap-behind, and in-pits classes from the driver-name element to the name-class-row container in opponent-delta.component.html. Updated related SCSS to style these classes on the container instead of the child element. Adjusted dashboard-page.component.spec.ts tests to reflect the new class location.