### PR TITLE
Improve fuel usage and estimation logic

### DIFF
--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -60,7 +60,8 @@ internal sealed class Display() : DisplayBase<DataSample>()
         {
             // Calculate fuel used in the last lap
             float fuelUsed = _lastLapStartFuel - telemetry.FuelLevel;
-            if (fuelUsed > 0) // Only add valid fuel usage
+            // Only add valid fuel usage (positive and not from pit stops)
+            if (fuelUsed > 0 && telemetry.FuelLevel <= _lastLapStartFuel)
             {
                 _fuelUsageHistory.Add(fuelUsed);
             }
@@ -101,7 +102,10 @@ internal sealed class Display() : DisplayBase<DataSample>()
             FuelRemaining = telemetry.FuelLevel,
             FuelLastLap = _fuelUsageHistory.Count > 0 ? _fuelUsageHistory[^1] : 0,
             FuelAvgLap = _fuelUsageHistory.Count > 0 ? _fuelUsageHistory.Average() : 0,
-            FuelEstLaps = _fuelUsageHistory.Count > 0 ? (int)(telemetry.FuelLevel / _fuelUsageHistory.Average()) : 0,
+            // Don't calculate estimated laps until we have fuel usage history
+            FuelEstLaps = _fuelUsageHistory.Count > 0 && _fuelUsageHistory.Average() > 0 
+                ? (int)(telemetry.FuelLevel / _fuelUsageHistory.Average()) 
+                : 0,
             AirTemp = telemetry.AirTemp,
             TrackTemp = telemetry.TrackTemp,
             PitLimiterOn = telemetry.EngineWarnings.HasFlag(EngineWarnings.PitSpeedLimiter),


### PR DESCRIPTION
Refined fuel usage calculation to exclude pit stop refueling and ensure only valid lap data is added. Updated estimated laps calculation to avoid division by zero and only compute when fuel usage history is available.