### PR TITLE
Feature: warn when fuel estimated laps insufficient

### DIFF
--- a/ClientApp/src/app/displays/race-display/race-display.component.html
+++ b/ClientApp/src/app/displays/race-display/race-display.component.html
@@ -91,10 +91,10 @@
               <div id="fuelRemaining">{{data().fuelRemaining |number:'1.1-1':'en-US'}} L</div>
             </div>
     
-            <div class="data-item">
-                <label>Fuel est. laps</label>
-                <div id="fuelEstLaps">{{data().fuelEstLaps |number:'1.1-1':'en-US'}}</div>
-            </div>
+      <div class="data-item">
+        <label>Fuel est. laps</label>
+        <div id="fuelEstLaps" [class.text-red]="data().totalLaps > 0 && ((data().totalLaps - data().currentLap) > data().fuelEstLaps)">{{data().fuelEstLaps |number:'1.1-1':'en-US'}}</div>
+      </div>
         </div>
     </div>
 

--- a/ClientApp/src/app/displays/race-display/race-display.component.spec.ts
+++ b/ClientApp/src/app/displays/race-display/race-display.component.spec.ts
@@ -144,6 +144,22 @@ describe('Race display component tests', () => {
     expect(await harness.getElementText('#fuelRemaining')).toEqual('14.2 L');
   });
 
+  describe('Fuel estimated laps warning', () => {
+    it('Shows red when laps remaining is larger than estimated laps', async () => {
+      // totalLaps - currentLap = 5, fuelEstLaps = 3 -> remaining laps (5) > est (3)
+      patchData({ currentLap: 2, totalLaps: 7, fuelEstLaps: 3 });
+
+      expect(await harness.elementHasClass('#fuelEstLaps', 'text-red')).toBe(true);
+    });
+
+    it('Does not show red when estimated laps covers remaining laps', async () => {
+      // totalLaps - currentLap = 3, fuelEstLaps = 4 -> remaining laps (3) <= est (4)
+      patchData({ currentLap: 2, totalLaps: 5, fuelEstLaps: 4 });
+
+      expect(await harness.elementHasClass('#fuelEstLaps', 'text-red')).toBe(false);
+    });
+  });
+
   describe('Best lap delta time', () => {
     it('Delta time is displayed', async () => {
       patchData({ bestLapTimeDelta: 0.231 });


### PR DESCRIPTION
Make fuel estimated laps text red when remaining laps exceed the estimate. Adds unit tests.