### PR TITLE
Add tire temperature fields to race data display

### DIFF
--- a/ClientApp/src/app/displays/race-display/race-data.ts
+++ b/ClientApp/src/app/displays/race-display/race-data.ts
@@ -1,6 +1,6 @@
 export interface RaceData {
   sessionType: string;
-  IsLimitedTime: boolean;
+  isLimitedTime: boolean;
   isLimitedSessionLaps: boolean;
   currentLap: number;
   totalLaps: number;
@@ -13,6 +13,11 @@ export interface RaceData {
   rpmMax: number;
   trackTemp: number;
   airTemp: number;
+  // Tire temperatures (degrees Celsius)
+  tireTempLf: number;
+  tireTempRf: number;
+  tireTempLr: number;
+  tireTempRr: number;
   fuelRemaining: number;
   fuelAvgLap: number;
   fuelLastLap: number;

--- a/ClientApp/src/app/displays/race-display/race-display.component.html
+++ b/ClientApp/src/app/displays/race-display/race-display.component.html
@@ -67,6 +67,26 @@
               <div id="bestLapTimeDelta" [class.text-green]="data().bestLapTimeDelta < 0" [class.text-red]="data().bestLapTimeDelta > 0">{{data().bestLapTimeDelta | deltatime}}</div>
           </div>
       </div>  
+      <div class="dashboard-row cols-2">
+          <div class="data-item">
+              <label>LF Temp</label>
+              <div>{{data().tireTempLf | number:'1.1-1':'en-US'}}</div>
+          </div>
+          <div class="data-item">
+              <label>RF Temp</label>
+              <div>{{data().tireTempRf | number:'1.1-1':'en-US'}}</div>
+          </div>
+      </div>  
+      <div class="dashboard-row cols-2">
+          <div class="data-item">
+              <label>LR Temp</label>
+              <div>{{data().tireTempLr | number:'1.1-1':'en-US'}}</div>
+          </div>
+          <div class="data-item">
+              <label>RR Temp</label>
+              <div>{{data().tireTempRr | number:'1.1-1':'en-US'}}</div>
+          </div>
+      </div>  
     </div>
   </div>
   <div class="dashboard-row cols-3">

--- a/HaddySimHub/Displays/IRacing/Display.cs
+++ b/HaddySimHub/Displays/IRacing/Display.cs
@@ -122,14 +122,17 @@ internal sealed class Display() : DisplayBase<DataSample>()
             FuelAvgLap = _fuelStintHistory.Count > 0 ? _fuelStintHistory.Average() : 0,
             // Don't calculate estimated laps until we have fuel usage history
             FuelEstLaps = _fuelStintHistory.Count > 0 && _fuelStintHistory.Average() > 0 
-                ? (int)(telemetry.FuelLevel / _fuelStintHistory.Average()) 
+                ? (telemetry.FuelLevel / _fuelStintHistory.Average()) 
                 : 0,
             AirTemp = telemetry.AirTemp,
             TrackTemp = telemetry.TrackTemp,
             PitLimiterOn = telemetry.EngineWarnings.HasFlag(EngineWarnings.PitSpeedLimiter),
+            TireTempLF = new[] { telemetry.LFtempCL, telemetry.LFtempCM, telemetry.LFtempCR }.Average(),
+            TireTempRF = new[] { telemetry.RFtempCL, telemetry.RFtempCM, telemetry.RFtempCR }.Average(),
+            TireTempLR = new[] { telemetry.LRtempCL, telemetry.LRtempCM, telemetry.LRtempCR }.Average(),
+            TireTempRR = new[] { telemetry.RRtempCL, telemetry.RRtempCM, telemetry.RRtempCR }.Average(),
             CarNumber = playerInfo?.CarNumber ?? string.Empty,
         };
-
         return new DisplayUpdate { Type = DisplayType.RaceDashboard, Data = displayUpdate };
     }
 

--- a/HaddySimHub/Models/RaceData.cs
+++ b/HaddySimHub/Models/RaceData.cs
@@ -36,7 +36,7 @@ public sealed record RaceData
 
     public float FuelLastLap { get; init; }
 
-    public int FuelEstLaps { get; init; }
+    public float FuelEstLaps { get; init; }
 
     public float BrakeBias { get; init; }
 
@@ -61,6 +61,11 @@ public sealed record RaceData
     public int ThrottlePct { get; init; }
 
     public int BrakePct { get; init; }
+
+    public float TireTempLF { get; init; }
+    public float TireTempRF { get; init; }
+    public float TireTempLR { get; init; }
+    public float TireTempRR { get; init; }
 
     public long Incidents { get; init; }
 


### PR DESCRIPTION
Introduces tire temperature fields (LF, RF, LR, RR) to RaceData model and updates the display component to show these values. Also changes FuelEstLaps type to float and fixes a property naming inconsistency for isLimitedTime.
