### PR TITLE
Add required tire temperature fields to RaceData

### DIFF
--- a/HaddySimHub/Displays/IRacing/TestDisplay.cs
+++ b/HaddySimHub/Displays/IRacing/TestDisplay.cs
@@ -44,6 +44,10 @@ namespace HaddySimHub.Displays.IRacing
                     BrakePct = brakePct,
                     ThrottlePct = throttlePct,
                     CarNumber = "80",
+                    TireTempLF = new Random().Next(40, 100),
+                    TireTempRF = new Random().Next(40, 100),
+                    TireTempLR = new Random().Next(40, 100),
+                    TireTempRR = new Random().Next(40, 100),
                 }
             };
         }

--- a/HaddySimHub/Models/RaceData.cs
+++ b/HaddySimHub/Models/RaceData.cs
@@ -62,10 +62,10 @@ public sealed record RaceData
 
     public int BrakePct { get; init; }
 
-    public float TireTempLF { get; init; }
-    public float TireTempRF { get; init; }
-    public float TireTempLR { get; init; }
-    public float TireTempRR { get; init; }
+    public required float TireTempLF { get; init; }
+    public required float TireTempRF { get; init; }
+    public required float TireTempLR { get; init; }
+    public required float TireTempRR { get; init; }
 
     public long Incidents { get; init; }
 


### PR DESCRIPTION
Marked tire temperature properties in RaceData as required and updated TestDisplay to generate random tire temperature values. This ensures tire temperature data is always provided when creating RaceData instances.
