### PR TITLE
Ignore test coverage files in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,6 +264,13 @@ __pycache__/
 # JUnit files
 TEST*.xml
 
+# Coverage reports
+coverage/
+htmlcov/
+.coverage
+coverage.xml
+cobertura.xml
+
 # Claude Code IDE temporary files
 .claude/
 tmpclaude-*


### PR DESCRIPTION
Add coverage-related patterns to .gitignore to avoid committing test coverage artifacts generated by local runs or CI: coverage/, htmlcov/, .coverage, coverage.xml, and cobertura.xml. Keeps the repository clean of transient report files.