### PR TITLE
chore: apply Angular 22 cleanups

### DIFF
--- a/ClientApp/eslint.config.mjs
+++ b/ClientApp/eslint.config.mjs
@@ -96,9 +96,9 @@ export default tseslint.config(
                     'style': 'camelCase'
                 }
             ],
-            '@angular-eslint/no-conflicting-lifecycle': 'error',
+            '@angular-eslint/contextual-lifecycle': 'error',
             '@angular-eslint/use-lifecycle-interface': 'error',
-            '@angular-eslint/prefer-on-push-component-change-detection': 'error',
+            '@angular-eslint/prefer-on-push-component-change-detection': 'off',
 
             // @stylistic/ts
             '@stylistic/semi': ['error', 'always'],
@@ -264,6 +264,13 @@ export default tseslint.config(
                 {
                     'name': 'rxjs/Rx',
                     'message': 'Please import directly from \'rxjs\' instead'
+                }
+            ],
+            'no-restricted-syntax': [
+                'error',
+                {
+                    'selector': 'Decorator[expression.callee.name="Component"] ObjectExpression > Property[key.name="changeDetection"]',
+                    'message': 'Do not set changeDetection in component metadata; use Angular default change detection behavior.'
                 }
             ],
             'no-undef': 'error',

--- a/ClientApp/package-lock.json
+++ b/ClientApp/package-lock.json
@@ -18,7 +18,6 @@
         "@angular/platform-browser-dynamic": "^22.0.0",
         "@angular/router": "^22.0.0",
         "@microsoft/signalr": "^10.0.0",
-        "@ngneat/until-destroy": "^10.0.0",
         "@ngrx/signals": "^21.1.0",
         "@stylistic/eslint-plugin": "^5.10.0",
         "bootstrap": "^5.3.8",
@@ -31,11 +30,11 @@
         "tslib": "^2.8.1"
       },
       "devDependencies": {
-        "@angular-eslint/builder": "21.4.0",
-        "@angular-eslint/eslint-plugin": "21.4.0",
-        "@angular-eslint/eslint-plugin-template": "21.4.0",
-        "@angular-eslint/schematics": "21.4.0",
-        "@angular-eslint/template-parser": "21.4.0",
+        "@angular-eslint/builder": "22.0.0",
+        "@angular-eslint/eslint-plugin": "22.0.0",
+        "@angular-eslint/eslint-plugin-template": "22.0.0",
+        "@angular-eslint/schematics": "22.0.0",
+        "@angular-eslint/template-parser": "22.0.0",
         "@angular/build": "^22.0.0",
         "@angular/cli": "~22.0.0",
         "@angular/compiler-cli": "^22.0.0",
@@ -48,7 +47,7 @@
         "@vitest/browser-playwright": "^4.1.8",
         "@vitest/coverage-v8": "^4.1.8",
         "@vitest/eslint-plugin": "^1.6.19",
-        "angular-eslint": "^21.4.0",
+        "angular-eslint": "^22.0.0",
         "baseline-browser-mapping": "^2.10.33",
         "cross-env": "^10.1.0",
         "eslint": "^9.39.2",
@@ -303,32 +302,32 @@
       }
     },
     "node_modules/@angular-devkit/architect": {
-      "version": "0.2102.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2102.11.tgz",
-      "integrity": "sha512-t7J8aaUho1mXjiIecPNX5/rjXeV8j8ZCGY5tD3ic5kzKxPkbuYYcQpJLdzlmBcN+wDgCmNdo8ySvItvU0m58lg==",
+      "version": "0.2200.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/architect/-/architect-0.2200.1.tgz",
+      "integrity": "sha512-Q3DfpgEIiHtG7uSUO8Tsm35rOeUbJfuxM9pi7cCyC8DvC/z1yNYm7/xEitlEYPzJmSLmks3eqlsaGnYhh0VLVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.11",
+        "@angular-devkit/core": "22.0.1",
         "rxjs": "7.8.2"
       },
       "bin": {
         "architect": "bin/cli.js"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-devkit/core": {
-      "version": "21.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.11.tgz",
-      "integrity": "sha512-kfMNh5X2hOdyr0uNFaaHUJR3OVr4oH2+UhI+FsTu7gqogdgYlHAVHhHAFulfDgtAEOiqpeSQF9RhQnCJl+/LXA==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-22.0.1.tgz",
+      "integrity": "sha512-77/WsCAbqGkumDfm/kkw2mFh/42DNF0hB02TvivlfiSC/KfK9DsHg7sKvTlNcuY14ZT/3iHhojLyNBc2HytuvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.18.0",
+        "ajv": "8.20.0",
         "ajv-formats": "3.0.1",
         "jsonc-parser": "3.3.1",
         "picomatch": "4.0.4",
@@ -336,7 +335,7 @@
         "source-map": "0.7.6"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       },
@@ -350,81 +349,81 @@
       }
     },
     "node_modules/@angular-devkit/schematics": {
-      "version": "21.2.11",
-      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.11.tgz",
-      "integrity": "sha512-69CWZ5/ftLdpUPAwwdAxTNosiGXUyvwdnOfmHsd9NvCT0OSTeq0eQ0UfnGcHASrXIVmnyWiNfBWM1DLqsgBXmw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-22.0.1.tgz",
+      "integrity": "sha512-GWou5meX3vAvqQEkox7xYMT9tIrYBVl0StbP7rGH5yMrzngvi6eyikMiUYnmMvoEoBK9gFNnXaAKeeu2aWvb3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": "21.2.11",
+        "@angular-devkit/core": "22.0.1",
         "jsonc-parser": "3.3.1",
         "magic-string": "0.30.21",
-        "ora": "9.3.0",
+        "ora": "9.4.0",
         "rxjs": "7.8.2"
       },
       "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+        "node": "^22.22.3 || ^24.15.0 || >=26.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
     },
     "node_modules/@angular-eslint/builder": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-21.4.0.tgz",
-      "integrity": "sha512-3kgGmrVaCYbLtDjC8g4BmMBbdz4thsOB8/NYly8JtXM8EuDZEk5Pz6VTRpJR02ARprwayraTTmhyvq6OGBlQ9w==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/builder/-/builder-22.0.0.tgz",
+      "integrity": "sha512-T2vWQYUhJs6iUlgocHV12OgoxbmN63f17a+tgW+3sYrKN0KAB3xuHsPOoYpRYoWqkVVC44HD441Ju4IDvo8vKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/architect": ">= 0.2100.0 < 0.2200.0",
-        "@angular-devkit/core": ">= 21.0.0 < 22.0.0"
+        "@angular-devkit/architect": ">= 0.2200.0 < 0.2300.0",
+        "@angular-devkit/core": ">= 22.0.0 < 23.0.0"
       },
       "peerDependencies": {
-        "@angular/cli": ">= 21.0.0 < 22.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@angular/cli": ">= 22.0.0 < 23.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/bundled-angular-compiler": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-21.4.0.tgz",
-      "integrity": "sha512-/3H4BPbQ1BHJkkrUsfusZtmHc+qiFWBBZ9UDPWah4xZMjflexOK9U4GYeH7nMjcuyqFnIlMMeJJNwNLGt/hmdg==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/bundled-angular-compiler/-/bundled-angular-compiler-22.0.0.tgz",
+      "integrity": "sha512-rv15vGDpGW8zZFaLdhQ+iIO1f0bZds/xvuxoX277hFisXp5Kt6FumJNNIb4g/qxq3xsY46a7fD6R7KvGY3smHg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@angular-eslint/eslint-plugin": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-21.4.0.tgz",
-      "integrity": "sha512-mow2DMj+xBvGl5t7jzC34R8YfbHbaGNyCNFzpovtl9qc0JbuqLyg6htmt8xb05f8ZjATOr4nz0ESt6HV4c51hw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin/-/eslint-plugin-22.0.0.tgz",
+      "integrity": "sha512-mKLScPZhqG64ic0KIQoxqSqCdkPwtEZuTOuunvc9lYTw05MJSHRUM2yVFODlCGq97c6BN1F6KBk2I+a+KFnr1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "21.4.0",
-        "@angular-eslint/utils": "21.4.0",
+        "@angular-eslint/bundled-angular-compiler": "22.0.0",
+        "@angular-eslint/utils": "22.0.0",
         "ts-api-utils": "^2.1.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@typescript-eslint/utils": "^8.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
     "node_modules/@angular-eslint/eslint-plugin-template": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-21.4.0.tgz",
-      "integrity": "sha512-sJEHx2WYnvOgPpzP1eHnUdRS06zgKmRxbiIR0JiCcaSen5iv1HlsMieXy//FS9TtNW+abHOy4UtDuGuSPflPFA==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/eslint-plugin-template/-/eslint-plugin-template-22.0.0.tgz",
+      "integrity": "sha512-y6XL5HJ8C31NpBvkVHpU3bWc+Rk9g1zRtHrs39omhuT29eEUcS3zu47HMFV6tf8rHOI97B2Mstg6qYS5XL9ATg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "21.4.0",
-        "@angular-eslint/utils": "21.4.0",
+        "@angular-eslint/bundled-angular-compiler": "22.0.0",
+        "@angular-eslint/utils": "22.0.0",
         "aria-query": "5.3.2",
         "axobject-query": "4.1.0"
       },
       "peerDependencies": {
-        "@angular-eslint/template-parser": "21.4.0",
-        "@typescript-eslint/types": "^7.11.0 || ^8.0.0",
-        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@angular-eslint/template-parser": "22.0.0",
+        "@typescript-eslint/types": "^8.0.0",
+        "@typescript-eslint/utils": "^8.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
@@ -442,22 +441,22 @@
       }
     },
     "node_modules/@angular-eslint/schematics": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-21.4.0.tgz",
-      "integrity": "sha512-crD6Hfxs7x5bN9FCqTZI7uVSiGvprfCS3MCPOpyIQl87bRr/9aNhnicJ3ROUHv+2A713BgPHIgiCII/bxzrfPw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/schematics/-/schematics-22.0.0.tgz",
+      "integrity": "sha512-gsJQx6c+WIWC5d+NAqn4rRdUzwhinUCTNmCM9x4wygV9DrbAfVG+6OFPEbaDMryNvf0HYDcnGclbIbXjukGCaw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
-        "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
-        "@angular-eslint/eslint-plugin": "21.4.0",
-        "@angular-eslint/eslint-plugin-template": "21.4.0",
+        "@angular-devkit/core": ">= 22.0.0 < 23.0.0",
+        "@angular-devkit/schematics": ">= 22.0.0 < 23.0.0",
+        "@angular-eslint/eslint-plugin": "22.0.0",
+        "@angular-eslint/eslint-plugin-template": "22.0.0",
         "ignore": "7.0.5",
-        "semver": "7.7.4",
+        "semver": "7.8.0",
         "strip-json-comments": "3.1.1"
       },
       "peerDependencies": {
-        "@angular/cli": ">= 21.0.0 < 22.0.0"
+        "@angular/cli": ">= 22.0.0 < 23.0.0"
       }
     },
     "node_modules/@angular-eslint/schematics/node_modules/ignore": {
@@ -470,18 +469,31 @@
         "node": ">= 4"
       }
     },
+    "node_modules/@angular-eslint/schematics/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@angular-eslint/template-parser": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-21.4.0.tgz",
-      "integrity": "sha512-BaUSLSyS+43fzDoJkTMkGqNdCXq3fGnUZsfXTmrlZPJf5AYFbgAlAPGZXDJyoNWw43fux+DafdlrlKcYUSgSIw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/template-parser/-/template-parser-22.0.0.tgz",
+      "integrity": "sha512-jU5MKQ24bBB4J99gSSexmUrLm2LvTJZCuCHhNTQ1LavWX4e1lrIxhm+6pJILOm6Cixf8jyNXnHMty6nljX8J+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "21.4.0",
+        "@angular-eslint/bundled-angular-compiler": "22.0.0",
         "eslint-scope": "9.1.2"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
@@ -505,17 +517,17 @@
       }
     },
     "node_modules/@angular-eslint/utils": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-21.4.0.tgz",
-      "integrity": "sha512-7pi+Ga7QmdH5Ig/diau6fR5L4yubgKr9TOjdCg7OeuE/zo0O3osTCNT6JOodzS/iQM1kSCJFDoIBKFeUOttiNw==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/@angular-eslint/utils/-/utils-22.0.0.tgz",
+      "integrity": "sha512-VFodMojghnPYm+B3U+HRYrqebPMj8NyobNjVzDdY8V5XIBW+4ivOSEINIz81G48rmm/NZKwj56+bJ88bVX4KIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-eslint/bundled-angular-compiler": "21.4.0"
+        "@angular-eslint/bundled-angular-compiler": "22.0.0"
       },
       "peerDependencies": {
-        "@typescript-eslint/utils": "^7.11.0 || ^8.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@typescript-eslint/utils": "^8.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*"
       }
     },
@@ -1135,23 +1147,6 @@
         "node": ">= 20"
       }
     },
-    "node_modules/@angular/build/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@angular/build/node_modules/esbuild": {
       "version": "0.28.0",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.0.tgz",
@@ -1325,23 +1320,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular/cli/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
     "node_modules/@angular/cli/node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -1353,19 +1331,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/@angular/cli/node_modules/cliui": {
@@ -1381,46 +1346,6 @@
       },
       "engines": {
         "node": ">=20"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/ora": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
-      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.2",
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/ora/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@angular/cli/node_modules/strip-ansi": {
@@ -4224,19 +4149,6 @@
         "node": ">= 10"
       }
     },
-    "node_modules/@ngneat/until-destroy": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/@ngneat/until-destroy/-/until-destroy-10.0.0.tgz",
-      "integrity": "sha512-xXFAabQ4YVJ82LYxdgUlaKZyR3dSbxqG3woSyaclzxfCgWMEDweCcM/GGYbNiHJa0WwklI98RXHvca+UyCxpeg==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.3.0"
-      },
-      "peerDependencies": {
-        "@angular/core": ">=13",
-        "rxjs": "^6.4.0 || ^7.0.0"
-      }
-    },
     "node_modules/@ngrx/signals": {
       "version": "21.1.0",
       "resolved": "https://registry.npmjs.org/@ngrx/signals/-/signals-21.1.0.tgz",
@@ -5362,105 +5274,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@schematics/angular/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/ansi-regex": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
-      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/chalk": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
-      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/ora": {
-      "version": "9.4.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
-      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chalk": "^5.6.2",
-        "cli-cursor": "^5.0.0",
-        "cli-spinners": "^3.2.0",
-        "is-interactive": "^2.0.0",
-        "is-unicode-supported": "^2.1.0",
-        "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.2",
-        "string-width": "^8.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/string-width": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
-      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/strip-ansi": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
-      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^6.2.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
-      }
-    },
     "node_modules/@sigstore/bundle": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sigstore/bundle/-/bundle-4.0.0.tgz",
@@ -6574,9 +6387,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6635,25 +6448,25 @@
       }
     },
     "node_modules/angular-eslint": {
-      "version": "21.4.0",
-      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-21.4.0.tgz",
-      "integrity": "sha512-LH7bWmtJvsubzwPoztnl1pWgI5X0VrfGTUITGSYcwn2J+SXuN/avzrKrxJmhUiIrNvLtfV+18GG6xZS1IGZdKg==",
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/angular-eslint/-/angular-eslint-22.0.0.tgz",
+      "integrity": "sha512-6tHLndzM6rU+2iuICakJS/hD1scK5sWLkcD7828zStT1ViA9zX8z9g/V1IlBiKEdZeMsl+m7K2DlNc34AkYyoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@angular-devkit/core": ">= 21.0.0 < 22.0.0",
-        "@angular-devkit/schematics": ">= 21.0.0 < 22.0.0",
-        "@angular-eslint/builder": "21.4.0",
-        "@angular-eslint/eslint-plugin": "21.4.0",
-        "@angular-eslint/eslint-plugin-template": "21.4.0",
-        "@angular-eslint/schematics": "21.4.0",
-        "@angular-eslint/template-parser": "21.4.0",
+        "@angular-devkit/core": ">= 22.0.0 < 23.0.0",
+        "@angular-devkit/schematics": ">= 22.0.0 < 23.0.0",
+        "@angular-eslint/builder": "22.0.0",
+        "@angular-eslint/eslint-plugin": "22.0.0",
+        "@angular-eslint/eslint-plugin-template": "22.0.0",
+        "@angular-eslint/schematics": "22.0.0",
+        "@angular-eslint/template-parser": "22.0.0",
         "@typescript-eslint/types": "^8.0.0",
         "@typescript-eslint/utils": "^8.0.0"
       },
       "peerDependencies": {
-        "@angular/cli": ">= 21.0.0 < 22.0.0",
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "@angular/cli": ">= 22.0.0 < 23.0.0",
+        "eslint": "^9.0.0 || ^10.0.0",
         "typescript": "*",
         "typescript-eslint": "^8.0.0"
       }
@@ -12146,9 +11959,9 @@
       }
     },
     "node_modules/ora": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/ora/-/ora-9.3.0.tgz",
-      "integrity": "sha512-lBX72MWFduWEf7v7uWf5DHp9Jn5BI8bNPGuFgtXMmr2uDz2Gz2749y3am3agSDdkhHPHYmmxEGSKH85ZLGzgXw==",
+      "version": "9.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-9.4.0.tgz",
+      "integrity": "sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -12158,7 +11971,7 @@
         "is-interactive": "^2.0.0",
         "is-unicode-supported": "^2.1.0",
         "log-symbols": "^7.0.1",
-        "stdin-discarder": "^0.3.1",
+        "stdin-discarder": "^0.3.2",
         "string-width": "^8.1.0"
       },
       "engines": {
@@ -12195,9 +12008,9 @@
       }
     },
     "node_modules/ora/node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -12,7 +12,7 @@
     "lint": "npm run lint:ts && npm run lint:styles",
     "lint:ts": "cross-env LINT_CONFIG=production ng lint --eslint-config eslint.config.mjs",
     "lint:styles": "stylelint \"**/*.scss\"",
-    "build:prod": "ng build --prod"
+    "build:prod": "ng build --configuration production"
   },
   "private": true,
   "engines": {
@@ -30,7 +30,6 @@
     "@angular/platform-browser-dynamic": "^22.0.0",
     "@angular/router": "^22.0.0",
     "@microsoft/signalr": "^10.0.0",
-    "@ngneat/until-destroy": "^10.0.0",
     "@ngrx/signals": "^21.1.0",
     "@stylistic/eslint-plugin": "^5.10.0",
     "bootstrap": "^5.3.8",
@@ -43,11 +42,11 @@
     "tslib": "^2.8.1"
   },
   "devDependencies": {
-    "@angular-eslint/builder": "21.4.0",
-    "@angular-eslint/eslint-plugin": "21.4.0",
-    "@angular-eslint/eslint-plugin-template": "21.4.0",
-    "@angular-eslint/schematics": "21.4.0",
-    "@angular-eslint/template-parser": "21.4.0",
+    "@angular-eslint/builder": "22.0.0",
+    "@angular-eslint/eslint-plugin": "22.0.0",
+    "@angular-eslint/eslint-plugin-template": "22.0.0",
+    "@angular-eslint/schematics": "22.0.0",
+    "@angular-eslint/template-parser": "22.0.0",
     "@angular/build": "^22.0.0",
     "@angular/cli": "~22.0.0",
     "@angular/compiler-cli": "^22.0.0",
@@ -60,7 +59,7 @@
     "@vitest/browser-playwright": "^4.1.8",
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/eslint-plugin": "^1.6.19",
-    "angular-eslint": "^21.4.0",
+    "angular-eslint": "^22.0.0",
     "baseline-browser-mapping": "^2.10.33",
     "cross-env": "^10.1.0",
     "eslint": "^9.39.2",

--- a/ClientApp/src/app/app.component.ts
+++ b/ClientApp/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ClockComponent, ConnectionStatusComponent } from './shared';
 import { RaceDisplayComponent, RallyDisplayComponent, TruckDisplayComponent } from './displays';
 import { DisplayType } from './signalr.service';
@@ -15,7 +15,6 @@ import { APP_STORE } from './state/app.store';
     ConnectionStatusComponent,
     ClockComponent,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AppComponent {
   private readonly _store = inject(APP_STORE);

--- a/ClientApp/src/app/displays/race-display/race-display.component.ts
+++ b/ClientApp/src/app/displays/race-display/race-display.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, inject } from '@angular/core';
+import { Component, ViewEncapsulation, inject } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { DeltaTimePipe, LapTimePipe, SpeedometerComponent } from '../../shared';
 import { TelemetryTraceComponent } from './telemetry-trace.component';
@@ -9,7 +9,6 @@ import { APP_STORE } from '../../state/app.store';
   selector: 'app-race-display',
   templateUrl: 'race-display.component.html',
   styleUrl: 'race-display.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
   encapsulation: ViewEncapsulation.None,
   imports: [
     DecimalPipe,

--- a/ClientApp/src/app/displays/race-display/telemetry-trace.component.ts
+++ b/ClientApp/src/app/displays/race-display/telemetry-trace.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, Input, OnInit, signal } from '@angular/core';
+import { Component, Input, OnInit, signal } from '@angular/core';
 import { ChartConfiguration } from 'chart.js';
 import { BaseChartDirective } from 'ng2-charts';
 
@@ -13,7 +13,6 @@ export interface TelemetrySample {
   templateUrl: './telemetry-trace.component.html',
   styleUrl: './telemetry-trace.component.scss',
   imports: [BaseChartDirective],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TelemetryTraceComponent implements OnInit {
   private readonly _maxFrames = 1_000;

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.ts
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { SpeedometerComponent, LapTimePipe } from '../../shared';
 import { APP_STORE } from '../../state/app.store';
 
@@ -13,7 +13,6 @@ export type { RallyData } from './rally-data';
     SpeedometerComponent,
     LapTimePipe,
   ],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class RallyDisplayComponent {
   private readonly _store = inject(APP_STORE);

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject, ViewEncapsulation } from '@angular/core';
+import { Component, inject, ViewEncapsulation } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { WaypointComponent } from './waypoint.component';
 import { TimespanPipe, NumberNlPipe, NumberFlexDigitPipe } from '../../shared';
@@ -12,7 +12,6 @@ export type { TruckData } from './truck-data';
   templateUrl: 'truck-display.component.html',
   styleUrl: 'truck-display.component.scss',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [
     DecimalPipe,
     TimespanPipe,

--- a/ClientApp/src/app/displays/truck-display/waypoint.component.ts
+++ b/ClientApp/src/app/displays/truck-display/waypoint.component.ts
@@ -1,9 +1,8 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 @Component({
   selector: 'app-waypoint',
   template: '<div class="data-item">{{description()}}</div>',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class WaypointComponent {
   public readonly city = input<string>();

--- a/ClientApp/src/app/shared/clock/clock.component.ts
+++ b/ClientApp/src/app/shared/clock/clock.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { ClockService } from './clock.service';
 import { DatePipe } from '@angular/common';
 
@@ -6,7 +6,6 @@ import { DatePipe } from '@angular/common';
   selector: 'app-clock',
   templateUrl: './clock.component.html',
   imports: [DatePipe],
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ClockComponent {
   private readonly _clockService = inject(ClockService);

--- a/ClientApp/src/app/shared/clock/clock.service.ts
+++ b/ClientApp/src/app/shared/clock/clock.service.ts
@@ -1,19 +1,19 @@
-import { computed, Injectable, signal } from '@angular/core';
-import { UntilDestroy, untilDestroyed } from '@ngneat/until-destroy';
-import { tap, timer } from 'rxjs';
+import { computed, OnDestroy, Service, signal } from '@angular/core';
+import { Subscription, tap, timer } from 'rxjs';
 
-@UntilDestroy()
-@Injectable({
-  providedIn: 'root',
-})
-export class ClockService {
+@Service()
+export class ClockService implements OnDestroy {
   private readonly _currentTime = signal(new Date());
+  private readonly _clockSubscription: Subscription;
   public readonly currentTime = computed(() => this._currentTime());
 
   public constructor() {
-    timer(0, 1000).pipe(
+    this._clockSubscription = timer(0, 1000).pipe(
       tap(() => this._currentTime.set(new Date())),
-      untilDestroyed(this),
     ).subscribe();
+  }
+
+  public ngOnDestroy(): void {
+    this._clockSubscription.unsubscribe();
   }
 }

--- a/ClientApp/src/app/shared/connection-status/connection-status.component.ts
+++ b/ClientApp/src/app/shared/connection-status/connection-status.component.ts
@@ -1,11 +1,10 @@
-import { ChangeDetectionStrategy, Component, computed, inject } from '@angular/core';
+import { Component, computed, inject } from '@angular/core';
 import { ConnectionStatus, SignalRService } from '../../signalr.service';
 
 @Component({
   selector: 'app-connection-status',
   templateUrl: './connection-status.component.html',
   styleUrl: './connection-status.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConnectionStatusComponent {
   private readonly _signalRService = inject(SignalRService);

--- a/ClientApp/src/app/shared/gauge/gauge.component.ts
+++ b/ClientApp/src/app/shared/gauge/gauge.component.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 
 @Component({
   selector: 'app-gauge',
   templateUrl: './gauge.component.html',
   styleUrl: './gauge.component.scss',
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GaugeComponent {
   public readonly value = input.required<number>();

--- a/ClientApp/src/app/shared/speedometer/speedometer.component.ts
+++ b/ClientApp/src/app/shared/speedometer/speedometer.component.ts
@@ -1,10 +1,9 @@
-import { ChangeDetectionStrategy, Component, ViewEncapsulation, input } from '@angular/core';
+import { Component, ViewEncapsulation, input } from '@angular/core';
 
 @Component({
   selector: 'app-speedometer',
   templateUrl: './speedometer.component.html',
   encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SpeedometerComponent {
   public readonly speed = input.required<number>();

--- a/ClientApp/src/app/signalr.service.ts
+++ b/ClientApp/src/app/signalr.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable, OnDestroy, signal } from '@angular/core';
+import { inject, OnDestroy, Service, signal } from '@angular/core';
 import { filter, interval, Subscription, take, tap } from 'rxjs';
 import { HttpTransportType, HubConnection, HubConnectionBuilder, IHttpConnectionOptions, LogLevel } from '@microsoft/signalr';
 import { RaceData, RallyData, TruckData } from './displays';
@@ -29,9 +29,7 @@ export interface DisplayUpdate {
   data: TruckData | RaceData | RallyData | undefined;
 }
 
-@Injectable({
-  providedIn: 'root',
-})
+@Service()
 export class SignalRService implements OnDestroy {
   private readonly _store = inject(APP_STORE);
   private readonly _hubConnection: HubConnection;

--- a/ClientApp/src/main.ts
+++ b/ClientApp/src/main.ts
@@ -1,8 +1,8 @@
-import { enableProdMode, importProvidersFrom, provideZonelessChangeDetection } from '@angular/core';
+import { enableProdMode, provideZonelessChangeDetection } from '@angular/core';
 import { environment } from './environments/environment';
 import { AppComponent } from './app/app.component';
 import { withInterceptorsFromDi, provideHttpClient, withXhr } from '@angular/common/http';
-import { BrowserModule, bootstrapApplication } from '@angular/platform-browser';
+import { bootstrapApplication } from '@angular/platform-browser';
 import { provideCharts, withDefaultRegisterables } from 'ng2-charts';
 
 if (environment.production) {
@@ -11,7 +11,6 @@ if (environment.production) {
 
 bootstrapApplication(AppComponent, {
   providers: [
-    importProvidersFrom(BrowserModule),
     provideHttpClient(withXhr(), withInterceptorsFromDi()),
     provideZonelessChangeDetection(),
     provideCharts(withDefaultRegisterables()),


### PR DESCRIPTION
Summary:
- migrate app services to Service decorator
- update angular-eslint packages to v22 and adapt renamed lifecycle rule
- remove explicit changeDetection from all component metadata and enforce with ESLint
- replace until-destroy usage in ClockService with native cleanup
- modernize build prod script and simplify bootstrap providers in main.ts

Notes:
- aligns codebase with Angular 22 defaults and current conventions