### PR TITLE
Add ACC shared-memory reconnect retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project are documented in this file.
 
+## v0.1.499 - 2026-06-19
+
+### Fixed
+- ACC no longer fails to deliver data when the game starts after the app. The provider now retries connecting to shared memory on every polling tick, so telemetry begins flowing as soon as the game is available.
+
+### Tests
+- Added `SharedMemoryGameDataProviderTests` to verify that the provider retries until shared memory becomes available.
+
 ## v0.1.498 - 2026-06-19
 
 ### Changed

--- a/HaddySimHub.Tests/SharedMemoryGameDataProviderTests.cs
+++ b/HaddySimHub.Tests/SharedMemoryGameDataProviderTests.cs
@@ -1,0 +1,85 @@
+using HaddySimHub.Displays;
+using HaddySimHub.Interfaces;
+using HaddySimHub.Models;
+
+namespace HaddySimHub.Tests;
+
+[TestClass]
+public class SharedMemoryGameDataProviderTests
+{
+    [TestMethod]
+    public async Task Start_RetriesUntilSharedMemoryBecomesAvailable()
+    {
+        var reader = new TestReader { Value = 42 };
+        var provider = new RetryingProvider(reader, connectSuccessAttempt: 2);
+        var received = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        provider.DataReceived += (_, telemetry) => received.TrySetResult(telemetry);
+
+        provider.Start();
+
+        var completed = await Task.WhenAny(received.Task, Task.Delay(1000));
+        provider.Stop();
+
+        Assert.AreSame(received.Task, completed);
+        Assert.AreEqual(42, await received.Task);
+        Assert.IsTrue(reader.ConnectAttempts >= 2);
+    }
+
+    private sealed class TestReader
+    {
+        public int ConnectAttempts { get; set; }
+        public bool IsConnected { get; set; }
+        public int Value { get; set; }
+    }
+
+    private sealed class RetryingProvider : SharedMemoryGameDataProviderBase<TestReader, int>
+    {
+        private readonly TestReader _reader;
+        private readonly int _connectSuccessAttempt;
+
+        public RetryingProvider(TestReader reader, int connectSuccessAttempt)
+        {
+            _reader = reader;
+            _connectSuccessAttempt = connectSuccessAttempt;
+        }
+
+        protected override TestReader CreateReader()
+        {
+            return _reader;
+        }
+
+        protected override void ConnectReader(TestReader reader)
+        {
+            reader.ConnectAttempts++;
+            if (reader.ConnectAttempts >= _connectSuccessAttempt)
+            {
+                reader.IsConnected = true;
+            }
+        }
+
+        protected override void DisconnectReader(TestReader? reader)
+        {
+            if (reader != null)
+            {
+                reader.IsConnected = false;
+            }
+        }
+
+        protected override bool IsConnected(TestReader? reader)
+        {
+            return reader?.IsConnected ?? false;
+        }
+
+        protected override bool TryReadTelemetry(TestReader reader, out int telemetry)
+        {
+            telemetry = reader.Value;
+            return reader.IsConnected;
+        }
+
+        protected override bool HasDataChanged(int current, int last)
+        {
+            return current != last;
+        }
+    }
+}

--- a/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
+++ b/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
@@ -5,8 +5,7 @@ namespace HaddySimHub.Displays.ACC;
 public class ACCGameDataProvider : SharedMemoryGameDataProviderBase<ACCSharedMemoryReader, ACCTelemetry>
 {
     private DateTime _lastDataLog = DateTime.MinValue;
-    private int _missedReads;
-    
+
     public override void Start()
     {
         Logger.Info("[ACC] Starting game data provider");
@@ -28,43 +27,20 @@ public class ACCGameDataProvider : SharedMemoryGameDataProviderBase<ACCSharedMem
         base.Stop();
     }
 
-    protected override void UpdateTelemetry(object? state)
+    protected override void OnMissedConnection(int consecutiveCount)
     {
-        if (Reader == null)
+        if (consecutiveCount == 1 || consecutiveCount % 100 == 0)
         {
-            return;
+            Logger.Debug($"[ACC] UpdateTelemetry: not connected ({consecutiveCount} consecutive misses)");
         }
+    }
 
-        if (!IsConnected(Reader))
+    protected override void OnDataChanged(ACCTelemetry telemetry)
+    {
+        if ((DateTime.Now - _lastDataLog).TotalSeconds > 5)
         {
-            _missedReads++;
-            if (_missedReads == 1 || _missedReads % 100 == 0)
-            {
-                Logger.Debug($"[ACC] UpdateTelemetry: not connected ({_missedReads} consecutive misses)");
-            }
-
-            ConnectReader(Reader);
-            if (!IsConnected(Reader))
-            {
-                return;
-            }
-        }
-
-        _missedReads = 0;
-
-        if (TryReadTelemetry(Reader, out var telemetry))
-        {
-            if (HasDataChanged(telemetry, LastTelemetry))
-            {
-                LastTelemetry = telemetry;
-                OnDataReceived(telemetry);
-                
-                if ((DateTime.Now - _lastDataLog).TotalSeconds > 5)
-                {
-                    Logger.Debug($"[ACC] Telemetry: RPM={telemetry.Rpms:F0} Speed={telemetry.SpeedKmh:F1} Gear={telemetry.Gear}");
-                    _lastDataLog = DateTime.Now;
-                }
-            }
+            Logger.Debug($"[ACC] Telemetry: RPM={telemetry.Rpms:F0} Speed={telemetry.SpeedKmh:F1} Gear={telemetry.Gear}");
+            _lastDataLog = DateTime.Now;
         }
     }
 

--- a/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
+++ b/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
@@ -30,18 +30,28 @@ public class ACCGameDataProvider : SharedMemoryGameDataProviderBase<ACCSharedMem
 
     protected override void UpdateTelemetry(object? state)
     {
-        if (Reader == null || !IsConnected(Reader))
+        if (Reader == null)
+        {
+            return;
+        }
+
+        if (!IsConnected(Reader))
         {
             _missedReads++;
             if (_missedReads == 1 || _missedReads % 100 == 0)
             {
                 Logger.Debug($"[ACC] UpdateTelemetry: not connected ({_missedReads} consecutive misses)");
             }
-            return;
+
+            ConnectReader(Reader);
+            if (!IsConnected(Reader))
+            {
+                return;
+            }
         }
 
         _missedReads = 0;
-        
+
         if (TryReadTelemetry(Reader, out var telemetry))
         {
             if (HasDataChanged(telemetry, LastTelemetry))

--- a/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
+++ b/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
@@ -29,12 +29,8 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
         ThrowIfDisposed();
         Reader = CreateReader();
         ConnectReader(Reader);
-
-        if (IsConnected(Reader))
-        {
-            // Update at ~100Hz (10ms intervals)
-            UpdateTimer?.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
-        }
+        // Keep polling even if the game starts after the app so shared memory can come up later.
+        UpdateTimer?.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
     }
 
     public virtual void Stop()
@@ -79,9 +75,18 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
     /// </summary>
     protected virtual void UpdateTelemetry(object? state)
     {
-        if (Reader == null || !IsConnected(Reader))
+        if (Reader == null)
         {
             return;
+        }
+
+        if (!IsConnected(Reader))
+        {
+            ConnectReader(Reader);
+            if (!IsConnected(Reader))
+            {
+                return;
+            }
         }
 
         if (TryReadTelemetry(Reader, out var telemetry))

--- a/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
+++ b/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
@@ -16,6 +16,7 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
     protected Timer? UpdateTimer { get; set; }
     protected TTelemetry LastTelemetry { get; set; }
     private bool _disposed;
+    private int _consecutiveMissedConnections;
 
     public event EventHandler<TTelemetry>? DataReceived;
 
@@ -71,6 +72,18 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
     protected abstract bool HasDataChanged(TTelemetry current, TTelemetry last);
 
     /// <summary>
+    /// Called each polling tick when the reader is not connected. Consecutive count starts at 1.
+    /// Override to add logging or metrics without duplicating the retry logic.
+    /// </summary>
+    protected virtual void OnMissedConnection(int consecutiveCount) { }
+
+    /// <summary>
+    /// Called when new telemetry is received and differs from the previous value.
+    /// Override to add per-provider logging without duplicating the polling loop.
+    /// </summary>
+    protected virtual void OnDataChanged(TTelemetry telemetry) { }
+
+    /// <summary>
     /// Called when telemetry update occurs. Can be overridden for logging.
     /// </summary>
     protected virtual void UpdateTelemetry(object? state)
@@ -82,6 +95,8 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
 
         if (!IsConnected(Reader))
         {
+            _consecutiveMissedConnections++;
+            OnMissedConnection(_consecutiveMissedConnections);
             ConnectReader(Reader);
             if (!IsConnected(Reader))
             {
@@ -89,12 +104,15 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
             }
         }
 
+        _consecutiveMissedConnections = 0;
+
         if (TryReadTelemetry(Reader, out var telemetry))
         {
             if (HasDataChanged(telemetry, LastTelemetry))
             {
                 LastTelemetry = telemetry;
                 OnDataReceived(telemetry);
+                OnDataChanged(telemetry);
             }
         }
     }


### PR DESCRIPTION
## What
Add retry-based reconnect handling for ACC shared-memory telemetry so providers continue polling when the game is not yet connected, and document the behavior in the changelog.

## How
- Updated SharedMemoryGameDataProviderBase to keep the polling timer active after Start() and attempt reconnects during telemetry updates when disconnected.
- Updated ACCGameDataProvider to apply the same reconnect-on-miss behavior and preserve ACC-specific missed-read diagnostics.
- Added SharedMemoryGameDataProviderTests.Start_RetriesUntilSharedMemoryBecomesAvailable to verify retry-until-available behavior.
- Added v0.1.499 changelog notes for ACC connection retry behavior.

## Risk
Low-to-moderate. Changes affect shared-memory connection lifecycle and telemetry polling timing, mainly in ACC and shared base provider behavior.

## Testing
- Added unit coverage in HaddySimHub.Tests/SharedMemoryGameDataProviderTests.cs.
- Local execution of dotnet test HaddySimHub.sln --no-restore is currently blocked in this environment because required SDK 10.0.201 is not installed.

## Follow-up
None