### PR TITLE
fix(deps): align @types/node with the Node 24 runtime

### DIFF
--- a/ClientApp/package-lock.json
+++ b/ClientApp/package-lock.json
@@ -41,7 +41,7 @@
         "@eslint/compat": "^2.1.0",
         "@eslint/js": "^10.0.0",
         "@stylistic/eslint-plugin-ts": "4.4.1",
-        "@types/node": "^26.0.0",
+        "@types/node": "^24.13.2",
         "@typescript-eslint/eslint-plugin": "^8.60.1",
         "@typescript-eslint/parser": "^8.60.1",
         "@vitest/browser": "^4.1.8",
@@ -4497,13 +4497,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "26.0.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.0.tgz",
-      "integrity": "sha512-vf2YFi1iY9lHGwNJMs01biZFbKJkrZR1T6/MlzjhJLPdntOHLhTrDSnSVcdtvjihi4VQNlrFRIxLsDBlQpAipA==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~8.3.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/semver": {
@@ -13532,9 +13532,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
-      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },

--- a/ClientApp/package.json
+++ b/ClientApp/package.json
@@ -58,7 +58,7 @@
     "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.0",
     "@stylistic/eslint-plugin-ts": "4.4.1",
-    "@types/node": "^26.0.0",
+    "@types/node": "^24.13.2",
     "@typescript-eslint/eslint-plugin": "^8.60.1",
     "@typescript-eslint/parser": "^8.60.1",
     "@vitest/browser": "^4.1.8",


### PR DESCRIPTION
## Summary

Follow-up correction to #400. The project targets **Node 24.15.0** (`package.json` engines `^24.15.0`, CI `node_version: 24.15.0`, local toolchain), but #400 bumped `@types/node` to `^26.0.0`.

`@types/node`'s major should track the Node runtime major. Node 26 types on a Node 24 runtime allow code to type-check against APIs that don't exist at runtime. This pins `@types/node` back to the latest Node 24 line (`^24.13.2`).

The project was **not** upgraded to Node 26 (that would be a separate, larger change to engines + CI + runtime verification).

## Verification
`npm run build` ✅ · `test_ci` 112/112 ✅ · `lint` ✅

🤖 Generated with [GitHub Copilot CLI](https://github.com/features/copilot)