### PR TITLE
Fix console dashboard rendering and test display order

### DIFF
--- a/HaddySimHub.Tests/ConsoleDashboardTests.cs
+++ b/HaddySimHub.Tests/ConsoleDashboardTests.cs
@@ -1,0 +1,77 @@
+using HaddySimHub;
+using HaddySimHub.Dashboard;
+using HaddySimHub.Displays;
+using HaddySimHub.Tests.Mocks;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+
+namespace HaddySimHub.Tests
+{
+    [TestClass]
+    public class ConsoleDashboardTests
+    {
+        private sealed class FakeDisplay(string description) : IDisplay
+        {
+            public string Description { get; } = description;
+            public bool IsActive => false;
+            public void Start() { }
+            public void Stop() { }
+        }
+
+        private static ConsoleDashboard CreateDashboard(int gameCount)
+        {
+            var displays = Enumerable.Range(0, gameCount)
+                .Select(i => (IDisplay)new FakeDisplay($"Game {i}"))
+                .ToList();
+            var runner = new DisplaysRunner(displays, new MockDisplayUpdateSender());
+            return new ConsoleDashboard(displays, runner, new DashboardLogStore(), 3333);
+        }
+
+        private static int RenderedHeight(IRenderable renderable, int width, int height)
+        {
+            var writer = new StringWriter();
+            var console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(writer),
+            });
+            console.Profile.Width = width;
+            console.Profile.Height = height;
+            console.Write(renderable);
+
+            return writer.ToString()
+                .Split('\n')
+                .Count(line => line.Length > 0);
+        }
+
+        [TestMethod]
+        [DataRow(24)]
+        [DataRow(30)]
+        [DataRow(50)]
+        public void BuildLayout_FillsCompleteVerticalSpace(int windowHeight)
+        {
+            var dashboard = CreateDashboard(gameCount: 7);
+
+            var rendered = dashboard.BuildLayout(windowHeight);
+
+            var lines = RenderedHeight(rendered, width: 120, height: windowHeight);
+            Assert.AreEqual(
+                windowHeight,
+                lines,
+                $"Dashboard should fill all {windowHeight} terminal rows, but rendered {lines}.");
+        }
+
+        [TestMethod]
+        public void BuildLayout_WithManyGames_StillFillsVerticalSpace()
+        {
+            const int windowHeight = 40;
+            var dashboard = CreateDashboard(gameCount: 20);
+
+            var rendered = dashboard.BuildLayout(windowHeight);
+
+            var lines = RenderedHeight(rendered, width: 120, height: windowHeight);
+            Assert.AreEqual(windowHeight, lines);
+        }
+    }
+}

--- a/HaddySimHub/Dashboard/ConsoleDashboard.cs
+++ b/HaddySimHub/Dashboard/ConsoleDashboard.cs
@@ -44,6 +44,10 @@ public sealed class ConsoleDashboard
     {
         try
         {
+            // Clear any startup output so the dashboard renders from the top of
+            // a clean screen instead of being pushed below earlier log lines.
+            AnsiConsole.Clear();
+
             await AnsiConsole.Live(BuildLayout())
                 .AutoClear(true)
                 .Overflow(VerticalOverflow.Crop)
@@ -78,15 +82,32 @@ public sealed class ConsoleDashboard
         }
     }
 
-    private IRenderable BuildLayout()
-    {
-        var rows = new Rows(
-            BuildHeader(),
-            new Columns(BuildStatusPanel(), BuildGamesPanel()).Expand(),
-            BuildLogPanel(),
-            BuildFooter());
+    private IRenderable BuildLayout() => BuildLayout(GetWindowHeight());
 
-        return rows;
+    /// <summary>
+    /// Builds the full-screen dashboard layout for a terminal of the given
+    /// height. A Spectre <see cref="Layout"/> is used (rather than stacked
+    /// <c>Rows</c>) so the log panel expands to fill the complete vertical
+    /// space, btop-style, instead of leaving the terminal partially blank.
+    /// </summary>
+    internal IRenderable BuildLayout(int windowHeight)
+    {
+        // Status panel always shows three rows; the games panel shows one row
+        // per registered game (minimum one). The taller of the two, plus the
+        // rounded panel border, determines the body height.
+        var bodyContentRows = Math.Max(3, Math.Max(1, _displays.Count));
+        var bodyHeight = bodyContentRows + 2;
+
+        // header rule (1) + footer (1) + log panel border (2).
+        const int chrome = 4;
+        var logCapacity = Math.Max(5, windowHeight - bodyHeight - chrome);
+
+        return new Layout("root").SplitRows(
+            new Layout("header").Size(1).Update(BuildHeader()),
+            new Layout("body").Size(bodyHeight)
+                .Update(new Columns(BuildStatusPanel(), BuildGamesPanel()).Expand()),
+            new Layout("log").Ratio(1).Update(BuildLogPanel(logCapacity)),
+            new Layout("footer").Size(1).Update(BuildFooter()));
     }
 
     private IRenderable BuildHeader()
@@ -161,9 +182,8 @@ public sealed class ConsoleDashboard
         };
     }
 
-    private IRenderable BuildLogPanel()
+    private IRenderable BuildLogPanel(int maxLines)
     {
-        var maxLines = Math.Max(5, GetWindowHeight() - 16);
         var entries = _logStore.Snapshot(maxLines);
 
         var lines = new List<IRenderable>();
@@ -186,13 +206,6 @@ public sealed class ConsoleDashboard
         if (lines.Count == 0)
         {
             lines.Add(new Markup("[grey]Waiting for activity...[/]"));
-        }
-
-        // Pad with blank rows so the log panel always fills the remaining
-        // terminal height instead of shrinking to fit a few log lines.
-        while (lines.Count < maxLines)
-        {
-            lines.Add(new Markup(string.Empty));
         }
 
         return new Panel(new Rows(lines))

--- a/HaddySimHub/Extensions/ApplicationCompositionExtensions.cs
+++ b/HaddySimHub/Extensions/ApplicationCompositionExtensions.cs
@@ -38,8 +38,8 @@ public static class ApplicationCompositionExtensions
         services.RegisterGameDisplay<Displays.ACRally.ACRallyGameDataProvider, Displays.ACRally.ACRallyDataConverter, Displays.ACRally.ACRallyTelemetry>(DisplayDefinitions.Game.AcRally);
 
         services.AddSingleton<IDataConverter<DisplayUpdate, DisplayUpdate>, IdentityDataConverter<DisplayUpdate>>();
-        services.RegisterTestDisplay<Displays.Dirt2.TestDisplay>(DisplayDefinitions.TestIds.Rally);
         services.RegisterTestDisplay<Displays.IRacing.TestDisplay>(DisplayDefinitions.TestIds.Race);
+        services.RegisterTestDisplay<Displays.Dirt2.TestDisplay>(DisplayDefinitions.TestIds.Rally);
         services.RegisterTestDisplay<Displays.ETS.TestDisplay>(DisplayDefinitions.TestIds.Truck);
 
         services.AddSingleton<DisplaysRunner>();


### PR DESCRIPTION
## Summary

Two related console dashboard fixes:

- **Fill vertical space**: clear the screen on start and render the dashboard at full terminal height.
- **Test display order**: register the test displays in `race → rally → truck` order so the dashboard Games panel lists them in the same order they are cycled with `Ctrl+T` (defined in `Program.cs`). Previously they were registered `rally → race → truck`, causing a mismatch.

## Testing

- `dotnet build HaddySimHub/HaddySimHub.csproj` — succeeds, 0 warnings (`TreatWarningsAsErrors` enabled).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>