### PR TITLE
Add telemetry and shared-memory connection diagnostics

### DIFF
--- a/HaddySimHub.Shared/ProcessHelper.cs
+++ b/HaddySimHub.Shared/ProcessHelper.cs
@@ -9,5 +9,37 @@ namespace HaddySimHub.Shared
             var processes = Process.GetProcessesByName(processName);
             return processes.Length != 0;
         }
+
+        /// <summary>
+        /// Returns the distinct, sorted names of all currently running processes.
+        /// Useful for diagnosing why a game is not detected (i.e. the configured
+        /// process name does not match the actual executable name).
+        /// </summary>
+        public static IReadOnlyList<string> GetRunningProcessNames()
+        {
+            try
+            {
+                return Process.GetProcesses()
+                    .Select(p =>
+                    {
+                        try
+                        {
+                            return p.ProcessName;
+                        }
+                        catch
+                        {
+                            return string.Empty;
+                        }
+                    })
+                    .Where(name => !string.IsNullOrEmpty(name))
+                    .Distinct(StringComparer.OrdinalIgnoreCase)
+                    .OrderBy(name => name, StringComparer.OrdinalIgnoreCase)
+                    .ToList();
+            }
+            catch
+            {
+                return [];
+            }
+        }
     }
 }

--- a/HaddySimHub.Tests/ConsoleDashboardTests.cs
+++ b/HaddySimHub.Tests/ConsoleDashboardTests.cs
@@ -14,8 +14,71 @@ namespace HaddySimHub.Tests
         {
             public string Description { get; } = description;
             public bool IsActive => false;
+            public DateTime? LastUpdateUtc => null;
             public void Start() { }
             public void Stop() { }
+        }
+
+        private sealed class ConfigurableDisplay(string description, bool isActive, DateTime? lastUpdateUtc) : IDisplay
+        {
+            public string Description { get; } = description;
+            public bool IsActive { get; } = isActive;
+            public DateTime? LastUpdateUtc { get; } = lastUpdateUtc;
+            public void Start() { }
+            public void Stop() { }
+        }
+
+        private static string Render(IDisplay display)
+        {
+            var displays = new List<IDisplay> { display };
+            var runner = new DisplaysRunner(displays, new MockDisplayUpdateSender());
+            var dashboard = new ConsoleDashboard(displays, runner, new DashboardLogStore(), 3333);
+
+            var writer = new StringWriter();
+            var console = AnsiConsole.Create(new AnsiConsoleSettings
+            {
+                Ansi = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out = new AnsiConsoleOutput(writer),
+            });
+            console.Profile.Width = 120;
+            console.Profile.Height = 40;
+            console.Write(dashboard.BuildLayout(40));
+            return writer.ToString();
+        }
+
+        [TestMethod]
+        public void GamesPanel_NotRunning_ShowsNeitherWaitingNorLive()
+        {
+            var output = Render(new ConfigurableDisplay("Assetto Corsa", isActive: false, lastUpdateUtc: null));
+
+            StringAssert.Contains(output, "Assetto Corsa");
+            Assert.IsFalse(output.Contains("waiting for data"), "Inactive game must not show waiting state.");
+            Assert.IsFalse(output.Contains("live"), "Inactive game must not show live state.");
+        }
+
+        [TestMethod]
+        public void GamesPanel_RunningWithoutData_ShowsWaitingForData()
+        {
+            var output = Render(new ConfigurableDisplay("Assetto Corsa", isActive: true, lastUpdateUtc: null));
+
+            StringAssert.Contains(output, "waiting for data");
+        }
+
+        [TestMethod]
+        public void GamesPanel_RunningWithFreshData_ShowsLive()
+        {
+            var output = Render(new ConfigurableDisplay("Assetto Corsa", isActive: true, lastUpdateUtc: DateTime.UtcNow));
+
+            StringAssert.Contains(output, "live");
+        }
+
+        [TestMethod]
+        public void GamesPanel_RunningWithStaleData_ShowsNoData()
+        {
+            var output = Render(new ConfigurableDisplay("Assetto Corsa", isActive: true, lastUpdateUtc: DateTime.UtcNow.AddSeconds(-30)));
+
+            StringAssert.Contains(output, "no data for");
         }
 
         private static ConsoleDashboard CreateDashboard(int gameCount)

--- a/HaddySimHub.Tests/DisplayLifecycleTests.cs
+++ b/HaddySimHub.Tests/DisplayLifecycleTests.cs
@@ -50,6 +50,27 @@ public class DisplayLifecycleTests
         Assert.AreEqual("Fake", displays[0].Description);
     }
 
+    [TestMethod]
+    public async Task DisplayBase_TracksLastUpdate_AndResetsOnStop()
+    {
+        var provider = new CountingGameDataProvider();
+        var sender = new RecordingDisplayUpdateSender();
+        var converter = new CountingDataConverter();
+        var display = new CountingDisplay(provider, converter, sender);
+
+        Assert.IsNull(display.LastUpdateUtc, "No data received yet, so LastUpdateUtc should be null.");
+
+        display.Start();
+        provider.Emit(1);
+        await Task.Delay(20);
+
+        Assert.IsNotNull(display.LastUpdateUtc, "Receiving telemetry should stamp LastUpdateUtc.");
+
+        display.Stop();
+
+        Assert.IsNull(display.LastUpdateUtc, "Stopping should clear LastUpdateUtc so a restarted game is not shown as live.");
+    }
+
     private sealed class CountingDisplay : DisplayBase<int>
     {
         public CountingDisplay(
@@ -165,6 +186,7 @@ public class DisplayLifecycleTests
     {
         public string Description => "Fake";
         public bool IsActive => false;
+        public DateTime? LastUpdateUtc => null;
         public void Start() { }
         public void Stop() { }
     }

--- a/HaddySimHub/Dashboard/ConsoleDashboard.cs
+++ b/HaddySimHub/Dashboard/ConsoleDashboard.cs
@@ -160,12 +160,7 @@ public sealed class ConsoleDashboard
 
         foreach (var display in _displays)
         {
-            var active = SafeIsActive(display);
-            var marker = active ? "[green]●[/]" : "[grey37]○[/]";
-            var name = active
-                ? $"[white]{Markup.Escape(display.Description)}[/]"
-                : $"[grey]{Markup.Escape(display.Description)}[/]";
-            grid.AddRow($"{marker} {name}");
+            grid.AddRow(BuildGameRow(display));
         }
 
         if (_displays.Count == 0)
@@ -180,6 +175,47 @@ public sealed class ConsoleDashboard
             BorderStyle = Style.Parse("grey"),
             Expand = true,
         };
+    }
+
+    /// <summary>
+    /// Renders a single game row with a tri-state indicator so an operator can
+    /// tell the difference between "game not running", "running but no telemetry"
+    /// (the typical broken-integration case), and "telemetry flowing".
+    /// </summary>
+    private static string BuildGameRow(IDisplay display)
+    {
+        var name = Markup.Escape(display.Description);
+
+        if (!SafeIsActive(display))
+        {
+            return $"[grey37]○[/] [grey]{name}[/]";
+        }
+
+        var lastUpdate = SafeLastUpdate(display);
+        if (lastUpdate is null)
+        {
+            return $"[yellow]◐[/] [white]{name}[/] [yellow](running · waiting for data)[/]";
+        }
+
+        var age = DateTime.UtcNow - lastUpdate.Value;
+        if (age > TimeSpan.FromSeconds(5))
+        {
+            return $"[yellow]◐[/] [white]{name}[/] [yellow](running · no data for {FormatAge(age)})[/]";
+        }
+
+        return $"[green]●[/] [white]{name}[/] [grey](live · {FormatAge(age)} ago)[/]";
+    }
+
+    private static string FormatAge(TimeSpan age)
+    {
+        if (age < TimeSpan.Zero)
+        {
+            age = TimeSpan.Zero;
+        }
+
+        return age.TotalSeconds < 60
+            ? $"{age.TotalSeconds:F1}s"
+            : $"{(int)age.TotalMinutes}m{age.Seconds:D2}s";
     }
 
     private IRenderable BuildLogPanel(int maxLines)
@@ -242,6 +278,18 @@ public sealed class ConsoleDashboard
         catch
         {
             return false;
+        }
+    }
+
+    private static DateTime? SafeLastUpdate(IDisplay display)
+    {
+        try
+        {
+            return display.LastUpdateUtc;
+        }
+        catch
+        {
+            return null;
         }
     }
 

--- a/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
+++ b/HaddySimHub/Displays/ACC/ACCGameDataProvider.cs
@@ -6,34 +6,7 @@ public class ACCGameDataProvider : SharedMemoryGameDataProviderBase<ACCSharedMem
 {
     private DateTime _lastDataLog = DateTime.MinValue;
 
-    public override void Start()
-    {
-        Logger.Info("[ACC] Starting game data provider");
-        base.Start();
-
-        if (IsConnected(Reader))
-        {
-            Logger.Info("[ACC] Connected to ACC shared memory, starting data updates (10ms intervals)");
-        }
-        else
-        {
-            Logger.Info("[ACC] Not connected to shared memory. Will retry when game is detected...");
-        }
-    }
-
-    public override void Stop()
-    {
-        Logger.Info("[ACC] Stopping game data provider");
-        base.Stop();
-    }
-
-    protected override void OnMissedConnection(int consecutiveCount)
-    {
-        if (consecutiveCount == 1 || consecutiveCount % 100 == 0)
-        {
-            Logger.Debug($"[ACC] UpdateTelemetry: not connected ({consecutiveCount} consecutive misses)");
-        }
-    }
+    protected override string ProviderName => "ACC";
 
     protected override void OnDataChanged(ACCTelemetry telemetry)
     {

--- a/HaddySimHub/Displays/DisplayBase.cs
+++ b/HaddySimHub/Displays/DisplayBase.cs
@@ -9,10 +9,18 @@ namespace HaddySimHub.Displays;
 
 public abstract class DisplayBase<T> : IDisplay
 {
+    private const int ChannelCapacity = 256;
+
     private readonly object _sync = new();
     private Channel<DisplayUpdate>? _updateChannel;
     private Task? _sendLoopTask;
     private bool _isStarted;
+
+    private long _lastUpdateTicks;
+    private bool _firstDataLogged;
+    private DateTime _lastFlowLogUtc = DateTime.MinValue;
+    private long _droppedFrames;
+    private DateTime _lastDropLogUtc = DateTime.MinValue;
 
     protected readonly IGameDataProvider<T> _gameDataProvider;
     protected readonly IDataConverter<T, DisplayUpdate> _dataConverter;
@@ -20,6 +28,15 @@ public abstract class DisplayBase<T> : IDisplay
 
     public abstract string Description { get; }
     public abstract bool IsActive { get; }
+
+    public DateTime? LastUpdateUtc
+    {
+        get
+        {
+            var ticks = Interlocked.Read(ref _lastUpdateTicks);
+            return ticks == 0 ? null : new DateTime(ticks, DateTimeKind.Utc);
+        }
+    }
 
     public DisplayBase(
         IGameDataProvider<T> gameDataProvider,
@@ -40,13 +57,19 @@ public abstract class DisplayBase<T> : IDisplay
                 return;
             }
 
-            var updateChannel = Channel.CreateBounded<DisplayUpdate>(new BoundedChannelOptions(256)
+            var updateChannel = Channel.CreateBounded<DisplayUpdate>(new BoundedChannelOptions(ChannelCapacity)
             {
                 SingleReader = true,
                 SingleWriter = false,
                 FullMode = BoundedChannelFullMode.DropOldest
             });
             _updateChannel = updateChannel;
+
+            Interlocked.Exchange(ref _lastUpdateTicks, 0);
+            Interlocked.Exchange(ref _droppedFrames, 0);
+            _firstDataLogged = false;
+            _lastFlowLogUtc = DateTime.MinValue;
+            _lastDropLogUtc = DateTime.MinValue;
 
             _gameDataProvider.DataReceived += HandleDataReceived;
             _gameDataProvider.Start();
@@ -70,6 +93,9 @@ public abstract class DisplayBase<T> : IDisplay
             _isStarted = false;
             _gameDataProvider.DataReceived -= HandleDataReceived;
             _gameDataProvider.Stop();
+
+            Interlocked.Exchange(ref _lastUpdateTicks, 0);
+            _firstDataLogged = false;
 
             updateChannel = _updateChannel;
             sendLoopTask = _sendLoopTask;
@@ -109,8 +135,44 @@ public abstract class DisplayBase<T> : IDisplay
     {
         try
         {
+            if (Logger.IsDataLoggingEnabled && data is not null)
+            {
+                Logger.LogData(data);
+            }
+
             var update = _dataConverter.Convert(data);
-            _updateChannel?.Writer.TryWrite(update);
+
+            var nowUtc = DateTime.UtcNow;
+            Interlocked.Exchange(ref _lastUpdateTicks, nowUtc.Ticks);
+
+            if (!_firstDataLogged)
+            {
+                _firstDataLogged = true;
+                Logger.Info($"First telemetry received from {Description}");
+            }
+            else if ((nowUtc - _lastFlowLogUtc).TotalSeconds >= 5)
+            {
+                _lastFlowLogUtc = nowUtc;
+                Logger.Debug($"Telemetry flowing from {Description}");
+            }
+
+            var channel = _updateChannel;
+            if (channel is null)
+            {
+                return;
+            }
+
+            if (channel.Reader.CanCount && channel.Reader.Count >= ChannelCapacity)
+            {
+                var dropped = Interlocked.Increment(ref _droppedFrames);
+                if ((nowUtc - _lastDropLogUtc).TotalSeconds >= 5)
+                {
+                    _lastDropLogUtc = nowUtc;
+                    Logger.Warn($"Dropping telemetry frames for {Description} (buffer full, {dropped} dropped so far) - consumer not keeping up or no client connected");
+                }
+            }
+
+            channel.Writer.TryWrite(update);
         }
         catch (Exception ex)
         {

--- a/HaddySimHub/Displays/IDisplay.cs
+++ b/HaddySimHub/Displays/IDisplay.cs
@@ -4,6 +4,14 @@ public interface IDisplay
 {
     string Description { get; }
     bool IsActive { get; }
+
+    /// <summary>
+    /// UTC timestamp of the last telemetry update pushed by this display, or
+    /// <c>null</c> when no data has been received since it was last started.
+    /// Used by the dashboard to distinguish "process running" from "data flowing".
+    /// </summary>
+    DateTime? LastUpdateUtc { get; }
+
     void Start();
     void Stop();
 }

--- a/HaddySimHub/Displays/README.md
+++ b/HaddySimHub/Displays/README.md
@@ -55,6 +55,29 @@ Each game lives in its own folder under `Displays/` (e.g. `Displays/IRacing/`):
 5. Register it with `services.RegisterGameDisplay<TProvider, TConverter, T>(...)`
    in `ApplicationCompositionExtensions`.
 
+## Debugging a game that "doesn't work"
+
+The pipeline distinguishes two failure modes and surfaces both:
+
+- **Not detected** — `IsActive` is `false` because no process matches the
+  configured name. With `HADDYSIMHUB_DEBUG=1`, `DisplaysRunner` logs the list of
+  running process names when no display is active, so you can confirm the exact
+  executable name to put in `DisplayDefinitions`.
+- **Detected but no data** — the process runs (panel shows it) but no telemetry
+  arrives. The console dashboard's Games panel shows a tri-state marker:
+  `○` not running · `◐ running · waiting for data` · `● live · <age> ago`.
+  `DisplayBase` logs *"First telemetry received from …"* on the first frame and
+  shared-memory providers warn *"process detected but shared memory is not
+  connected"* via `SharedMemoryGameDataProviderBase`.
+
+Additional aids:
+
+- `Logger.Warn` is used for missed connections and dropped telemetry frames
+  (visible without debug mode).
+- With `HADDYSIMHUB_DEBUG=1`, every raw telemetry frame is serialised to
+  `log/<date>-HaddySimHub-data.log` via `Logger.LogData`, wired centrally in
+  `DisplayBase`, so converter mapping issues can be diagnosed offline.
+
 ## Test displays
 
 Test displays push sample data so the frontend can be exercised without a game

--- a/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
+++ b/HaddySimHub/Displays/SharedMemoryGameDataProviderBase.cs
@@ -30,6 +30,16 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
         ThrowIfDisposed();
         Reader = CreateReader();
         ConnectReader(Reader);
+
+        if (IsConnected(Reader))
+        {
+            Logger.Info($"[{ProviderName}] Connected to shared memory, polling for telemetry");
+        }
+        else
+        {
+            Logger.Warn($"[{ProviderName}] Shared memory not available yet - will keep retrying while the game is running");
+        }
+
         // Keep polling even if the game starts after the app so shared memory can come up later.
         UpdateTimer?.Change(TimeSpan.Zero, TimeSpan.FromMilliseconds(10));
     }
@@ -72,10 +82,29 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
     protected abstract bool HasDataChanged(TTelemetry current, TTelemetry last);
 
     /// <summary>
-    /// Called each polling tick when the reader is not connected. Consecutive count starts at 1.
-    /// Override to add logging or metrics without duplicating the retry logic.
+    /// A short tag identifying this provider in log output (e.g. "ACC").
+    /// Defaults to the type name with any "GameDataProvider" suffix trimmed.
     /// </summary>
-    protected virtual void OnMissedConnection(int consecutiveCount) { }
+    protected virtual string ProviderName =>
+        GetType().Name.Replace("GameDataProvider", string.Empty);
+
+    /// <summary>
+    /// Called each polling tick when the reader is not connected. Consecutive count starts at 1.
+    /// The default logs the first miss at warning level (so a "running but no data" game is
+    /// visible without debug logging) and every 100th miss thereafter at debug level.
+    /// Override and call <c>base.OnMissedConnection</c> to add metrics.
+    /// </summary>
+    protected virtual void OnMissedConnection(int consecutiveCount)
+    {
+        if (consecutiveCount == 1)
+        {
+            Logger.Warn($"[{ProviderName}] Game process detected but shared memory is not connected - retrying...");
+        }
+        else if (consecutiveCount % 100 == 0)
+        {
+            Logger.Debug($"[{ProviderName}] Still not connected to shared memory ({consecutiveCount} consecutive misses)");
+        }
+    }
 
     /// <summary>
     /// Called when new telemetry is received and differs from the previous value.
@@ -102,6 +131,11 @@ public abstract class SharedMemoryGameDataProviderBase<TReader, TTelemetry> : IG
             {
                 return;
             }
+        }
+
+        if (_consecutiveMissedConnections > 0)
+        {
+            Logger.Info($"[{ProviderName}] Reconnected to shared memory after {_consecutiveMissedConnections} missed attempts");
         }
 
         _consecutiveMissedConnections = 0;

--- a/HaddySimHub/DisplaysRunner.cs
+++ b/HaddySimHub/DisplaysRunner.cs
@@ -32,6 +32,11 @@ public class DisplaysRunner
                 if (_lastStateHadDisplays != false)
                 {
                      Logger.Info("No active displays found");
+                     if (Logger.IsDataLoggingEnabled)
+                     {
+                         var processNames = ProcessHelper.GetRunningProcessNames();
+                         Logger.Debug($"No game process detected. Running processes ({processNames.Count}): {string.Join(", ", processNames)}");
+                     }
                     _lastStateHadDisplays = false;
                 }
                 await _displayUpdateSender.SendDisplayUpdate(_idleDisplayUpdate);

--- a/HaddySimHub/Logger.cs
+++ b/HaddySimHub/Logger.cs
@@ -22,7 +22,26 @@ public static class Logger
     /// <inheritdoc/>
     public static void Info(string message) => _logger.Info(message);
 
-    public static void LogData(object data) => _logger.Trace($"{JsonSerializer.Serialize(data)}\n");
+    /// <inheritdoc/>
+    public static void Warn(string message) => _logger.Warn(message);
+
+    /// <summary>
+    /// Gets a value indicating whether per-frame raw telemetry logging is enabled
+    /// (only when <c>HADDYSIMHUB_DEBUG=1</c>). Callers should check this before
+    /// serialising telemetry so the JSON cost is not paid on every frame when the
+    /// data log is disabled.
+    /// </summary>
+    public static bool IsDataLoggingEnabled { get; private set; }
+
+    public static void LogData(object data)
+    {
+        if (!IsDataLoggingEnabled)
+        {
+            return;
+        }
+
+        _logger.Trace($"{JsonSerializer.Serialize(data)}\n");
+    }
 
     private static bool _dashboardConsole;
 
@@ -52,6 +71,7 @@ public static class Logger
     {
         // Check environment variable voor debug logging
         var enableDebugLogging = Environment.GetEnvironmentVariable("HADDYSIMHUB_DEBUG") == "1";
+        IsDataLoggingEnabled = enableDebugLogging;
 
         var logConfig = new LoggingConfiguration();
 


### PR DESCRIPTION
## Summary

Improves operator visibility into why a game shows as *running* but no telemetry is flowing — the most common broken-integration case.

## Changes

- **Dashboard tri-state indicator**: track `LastUpdateUtc` per display and render not-running / running-no-data / live in the console dashboard.
- **Flow logging**: log first-telemetry, periodic flow, reconnect, and dropped-frame events in `DisplayBase` and `SharedMemoryGameDataProviderBase`.
- **Logging plumbing**: gate per-frame raw telemetry serialisation behind `Logger.IsDataLoggingEnabled` and add `Logger.Warn`.
- **Deduplication**: hoist shared-memory connect/miss logging into the base provider via a `ProviderName` tag, removing ACC-specific overrides.
- **Process diagnostics**: list running process names when no display is detected (data logging on); add `ProcessHelper.GetRunningProcessNames`.

## Testing

- `dotnet test HaddySimHub.sln` → 205 passed, 0 failed.