### PR TITLE
feat(truck-display): damage/fuel warnings, gear advice, arrival time & rest-stop conflict

### DIFF
--- a/ClientApp/src/app/displays/truck-display/truck-data.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-data.ts
@@ -35,7 +35,8 @@ export interface TruckData {
   rpmMax: number;
   cruiseControlOn: boolean;
   cruiseControlSpeed: number;
-  gear: number;
+  gear: string;
+  recommendedGear: string;
   parkingLightsOn: boolean;
   lowBeamOn: boolean;
   highBeamOn: boolean;
@@ -47,7 +48,7 @@ export interface TruckData {
   fuelWarningOn: boolean;
   blinkerLeftOn: boolean;
   blinkerRightOn: boolean;
-  gameTime: Date;
+  gameTime: number;
   wipersOn: boolean;
   fuelAverageConsumption: number;
   throttle: number;

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.harness.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.harness.ts
@@ -1,4 +1,4 @@
-import { ComponentHarness } from '@angular/cdk/testing';
+import { ComponentHarness, TestElement } from '@angular/cdk/testing';
 import { SpeedometerComponentHarness } from '../../shared/speedometer/speedometer.component.harness';
 
 export class TruckDashComponentHarness extends ComponentHarness {
@@ -20,5 +20,10 @@ export class TruckDashComponentHarness extends ComponentHarness {
     const elm = await this.locatorFor(selector)();
     const text = await elm.text();
     return text;
+  }
+
+  public async locatorForElement(selector: string): Promise<TestElement> {
+    const elm = await this.locatorFor(selector)();
+    return elm;
   }
 }

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.html
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.html
@@ -107,28 +107,28 @@
             <div class="row">
               <div class="col-6">
                 <div class="data-label">Motor</div>
-                <div class="data-item">{{data().damageTruckEngine}} %</div>
+                <div class="data-item" id="damageTruckEngine" [class]="damageClass(data().damageTruckEngine)">{{data().damageTruckEngine}} %</div>
               </div>
               <div class="col-6">
                 <div class="data-label">Transmissie</div>
-                <div class="data-item">{{data().damageTruckTransmission}} %</div>
+                <div class="data-item" id="damageTruckTransmission" [class]="damageClass(data().damageTruckTransmission)">{{data().damageTruckTransmission}} %</div>
               </div>
             </div>
             <div class="row">
               <div class="col-6">
                 <div class="data-label">Cabine</div>
-                <div class="data-item">{{data().damageTruckCabin}} %</div>
+                <div class="data-item" id="damageTruckCabin" [class]="damageClass(data().damageTruckCabin)">{{data().damageTruckCabin}} %</div>
               </div>
               <div class="col-6">
                 <div class="data-label">Chassis</div>
-                <div class="data-item">{{data().damageTruckChassis}} %</div>
+                <div class="data-item" id="damageTruckChassis" [class]="damageClass(data().damageTruckChassis)">{{data().damageTruckChassis}} %</div>
               </div>
             </div>
 
             <div class="row">
               <div class="col-6">
                 <div class="data-label">Wielen</div>
-                <div class="data-item">{{data().damageTruckWheels}} %</div>
+                <div class="data-item" id="damageTruckWheels" [class]="damageClass(data().damageTruckWheels)">{{data().damageTruckWheels}} %</div>
               </div>
             </div>
           </div>
@@ -148,21 +148,21 @@
             <div class="row">
               <div class="col-6">
                 <div class="data-label">Chassis</div>
-                <div class="data-item">{{data().damageTrailerChassis}} %</div>
+                <div class="data-item" id="damageTrailerChassis" [class]="damageClass(data().damageTrailerChassis)">{{data().damageTrailerChassis}} %</div>
               </div>
               <div class="col-6">
                 <div class="data-label">Opbouw</div>
-                <div class="data-item">{{data().damageTrailerBody}} %</div>
+                <div class="data-item" id="damageTrailerBody" [class]="damageClass(data().damageTrailerBody)">{{data().damageTrailerBody}} %</div>
               </div>
             </div>
             <div class="row">
               <div class="col-6">
                 <div class="data-label">Wielen</div>
-                <div class="data-item">{{data().damageTrailerWheels}} %</div>
+                <div class="data-item" id="damageTrailerWheels" [class]="damageClass(data().damageTrailerWheels)">{{data().damageTrailerWheels}} %</div>
               </div>
               <div class="col-6">
                 <div class="data-label">Lading</div>
-                <div class="data-item">{{data().damageTrailerCargo}} %</div>
+                <div class="data-item" id="damageTrailerCargo" [class]="damageClass(data().damageTrailerCargo)">{{data().damageTrailerCargo}} %</div>
               </div>
             </div>
           </div>
@@ -210,7 +210,7 @@
         </div>
         <div class="icon-text-control" id="fuel">
           <img class="dashboard-light" src="/assets/images/fuel.svg" [class.filter-orange]="data().fuelWarningOn">
-          <div>{{data().fuelDistance | numberFlexDigit}} km ({{data().fuelAmount | numberFlexDigit}} l)</div>
+          <div [class.fuel-range-too-short]="fuelRangeTooShort()">{{data().fuelDistance | numberFlexDigit}} km ({{data().fuelAmount | numberFlexDigit}} l)</div>
         </div>
         <div class="icon-text-control"  id="adBlue">
           <img class="dashboard-light" src="/assets/images/adblue.svg" [class.filter-orange]="data().adBlueWarningOn">

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.html
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.html
@@ -22,6 +22,7 @@
                 @if (data().timeRemainingIrl > 0) {
                   <span>({{data().timeRemainingIrl | timespan}})</span>
                 }
+                <span class="arrival-time" id="arrivalTime">&rarr; aankomst {{arrivalTime()}}</span>
               </div>
             }
             @else {
@@ -31,7 +32,7 @@
           <div class="data-row">
             <div class="data-label">Volgend rustmoment</div>
             @if (data().restTimeRemaining) {
-              <div class="data-item">
+              <div class="data-item" id="nextRest" [class.rest-before-arrival]="restBeforeArrival()">
                 <span>{{data().restTimeRemaining | timespan}}&nbsp;</span>
                 @if (data().restTimeRemainingIrl > 0) {
                   <span>({{data().restTimeRemainingIrl | timespan}})</span>
@@ -174,9 +175,17 @@
   <div class="row">
     <div class="col-6">
       <div class="card gauge">
-        <app-gauge [value]="data().rpm" [max]="data().rpmMax" [greenStart]="1250" [greenEnd]="2000">
+        <app-gauge [value]="data().rpm" [max]="data().rpmMax" [greenStart]="rpmGreenZoneStart" [greenEnd]="rpmGreenZoneEnd">
           <label class="unit text-center rpm-scale">x 100 RPM</label>
           <div class="gear text-center">{{data().gear}}</div>
+          <div class="gear-advice text-center" id="gearAdvice" [class.hidden]="!gearAdvice()">
+            <span
+              class="shift-arrow"
+              id="shiftArrow"
+              [class.shift-arrow-up]="shiftDirection() === 'up'"
+              [class.shift-arrow-down]="shiftDirection() === 'down'"></span>
+            <span>Schakel naar {{gearAdvice()}}</span>
+          </div>
         </app-gauge>
       </div>
     </div>

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.scss
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.scss
@@ -129,6 +129,40 @@ app-truck-display {
     font-weight: 600;
   }
 
+  .arrival-time {
+    color: gray;
+  }
+
+  .rest-before-arrival {
+    color: orange;
+    font-weight: 600;
+  }
+
+  .shift-arrow {
+    width: 0;
+    height: 0;
+    border-left: 0.7vw solid transparent;
+    border-right: 0.7vw solid transparent;
+  }
+
+  .shift-arrow-up {
+    border-bottom: 0.9vw solid #0c6;
+  }
+
+  .shift-arrow-down {
+    border-top: 0.9vw solid orange;
+  }
+
+  .gear-advice {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5vw;
+    color: orange;
+    font-size: 1.2vw;
+    font-weight: 600;
+  }
+
   .card-header {
     border: none;
     padding-bottom: 0;

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.scss
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.scss
@@ -114,6 +114,21 @@ app-truck-display {
     font-size: 1.2vw;
   }
 
+  .damage-warning {
+    color: orange;
+    font-weight: 600;
+  }
+
+  .damage-critical {
+    color: red;
+    font-weight: 600;
+  }
+
+  .fuel-range-too-short {
+    color: red;
+    font-weight: 600;
+  }
+
   .card-header {
     border: none;
     padding-bottom: 0;

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
@@ -139,6 +139,84 @@ describe('TruckDisplayComponent', () => {
     });
   });
 
+  describe('Arrival time', () => {
+    it('Shows clock time from game time plus remaining route time', async () => {
+      patchData({ gameTime: 13 * 60 + 30, timeRemaining: 90 });
+
+      expect(await harness.getElementText('#arrivalTime')).toContain('15:00');
+    });
+
+    it('Wraps past midnight', async () => {
+      patchData({ gameTime: 23 * 60, timeRemaining: 120 });
+
+      expect(await harness.getElementText('#arrivalTime')).toContain('01:00');
+    });
+  });
+
+  describe('Rest stop conflict', () => {
+    it('No warning when arrival is before the next rest', async () => {
+      patchData({ restTimeRemaining: 180, timeRemaining: 90 });
+
+      const elm = await harness.locatorForElement('#nextRest');
+      expect(await elm.hasClass('rest-before-arrival')).toBe(false);
+    });
+
+    it('Warning when a rest is required before arrival', async () => {
+      patchData({ restTimeRemaining: 60, timeRemaining: 120 });
+
+      const elm = await harness.locatorForElement('#nextRest');
+      expect(await elm.hasClass('rest-before-arrival')).toBe(true);
+    });
+  });
+
+  describe('Gear advice', () => {
+    it('Shows advice when the recommended gear differs from the current gear', async () => {
+      patchData({ gear: '7', recommendedGear: '9' });
+
+      expect(await harness.getElementText('#gearAdvice')).toContain('9');
+      const elm = await harness.locatorForElement('#gearAdvice');
+      expect(await elm.hasClass('hidden')).toBe(false);
+    });
+
+    it('Shows an up arrow when the recommended gear is higher', async () => {
+      patchData({ gear: '7', recommendedGear: '9' });
+
+      const arrow = await harness.locatorForElement('#shiftArrow');
+      expect(await arrow.hasClass('shift-arrow-up')).toBe(true);
+      expect(await arrow.hasClass('shift-arrow-down')).toBe(false);
+    });
+
+    it('Shows a down arrow when the recommended gear is lower', async () => {
+      patchData({ gear: '9', recommendedGear: '7' });
+
+      const arrow = await harness.locatorForElement('#shiftArrow');
+      expect(await arrow.hasClass('shift-arrow-up')).toBe(false);
+      expect(await arrow.hasClass('shift-arrow-down')).toBe(true);
+    });
+
+    it('Shows no arrow direction when the current gear is not numeric', async () => {
+      patchData({ gear: 'C1', recommendedGear: '2' });
+
+      const arrow = await harness.locatorForElement('#shiftArrow');
+      expect(await arrow.hasClass('shift-arrow-up')).toBe(false);
+      expect(await arrow.hasClass('shift-arrow-down')).toBe(false);
+    });
+
+    it('Hides advice when the recommended gear matches the current gear', async () => {
+      patchData({ gear: '9', recommendedGear: '9' });
+
+      const elm = await harness.locatorForElement('#gearAdvice');
+      expect(await elm.hasClass('hidden')).toBe(true);
+    });
+
+    it('Hides advice when there is no recommendation', async () => {
+      patchData({ gear: '9', recommendedGear: '' });
+
+      const elm = await harness.locatorForElement('#gearAdvice');
+      expect(await elm.hasClass('hidden')).toBe(true);
+    });
+  });
+
   const patchData = (value: Record<string, unknown>): void => {
     mockStore.truckData.set(value as unknown as TruckData);
   };

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
@@ -90,6 +90,55 @@ describe('TruckDisplayComponent', () => {
     });
   });
 
+  describe('Damage highlight', () => {
+    it('No severity class below the warning threshold', async () => {
+      patchData({ damageTruckEngine: 10 });
+
+      const elm = await harness.locatorForElement('#damageTruckEngine');
+      expect(await elm.hasClass('damage-warning')).toBe(false);
+      expect(await elm.hasClass('damage-critical')).toBe(false);
+    });
+
+    it('Warning class between the warning and critical thresholds', async () => {
+      patchData({ damageTruckEngine: 30 });
+
+      const elm = await harness.locatorForElement('#damageTruckEngine');
+      expect(await elm.hasClass('damage-warning')).toBe(true);
+      expect(await elm.hasClass('damage-critical')).toBe(false);
+    });
+
+    it('Critical class at or above the critical threshold', async () => {
+      patchData({ damageTrailerCargo: 80 });
+
+      const elm = await harness.locatorForElement('#damageTrailerCargo');
+      expect(await elm.hasClass('damage-warning')).toBe(false);
+      expect(await elm.hasClass('damage-critical')).toBe(true);
+    });
+  });
+
+  describe('Fuel reachability', () => {
+    it('No warning when fuel range covers the remaining distance', async () => {
+      patchData({ fuelDistance: 800, distanceRemaining: 500 });
+
+      const elm = await harness.locatorForElement('#fuel > div');
+      expect(await elm.hasClass('fuel-range-too-short')).toBe(false);
+    });
+
+    it('Warning when fuel range is below the remaining distance', async () => {
+      patchData({ fuelDistance: 200, distanceRemaining: 500 });
+
+      const elm = await harness.locatorForElement('#fuel > div');
+      expect(await elm.hasClass('fuel-range-too-short')).toBe(true);
+    });
+
+    it('No warning when there is no active route', async () => {
+      patchData({ fuelDistance: 0, distanceRemaining: 0 });
+
+      const elm = await harness.locatorForElement('#fuel > div');
+      expect(await elm.hasClass('fuel-range-too-short')).toBe(false);
+    });
+  });
+
   const patchData = (value: Record<string, unknown>): void => {
     mockStore.truckData.set(value as unknown as TruckData);
   };

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.ts
@@ -1,4 +1,4 @@
-import { Component, inject, ViewEncapsulation } from '@angular/core';
+import { Component, computed, inject, ViewEncapsulation } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { WaypointComponent } from './waypoint.component';
 import { TimespanPipe, NumberNlPipe, NumberFlexDigitPipe } from '../../shared';
@@ -6,6 +6,10 @@ import { GaugeComponent } from '../../shared/gauge/gauge.component';
 import { APP_STORE } from '../../state/app.store';
 
 export type { TruckData } from './truck-data';
+
+const damageWarningThreshold = 25;
+const damageCriticalThreshold = 50;
+
 
 @Component({
   selector: 'app-truck-display',
@@ -24,4 +28,21 @@ export type { TruckData } from './truck-data';
 export class TruckDisplayComponent {
   private readonly _store = inject(APP_STORE);
   protected readonly data = this._store.truckData;
+
+  protected readonly fuelRangeTooShort = computed(() => {
+    const data = this.data();
+    return data.distanceRemaining > 0 && data.fuelDistance < data.distanceRemaining;
+  });
+
+  protected damageClass(value: number): string {
+    if (value >= damageCriticalThreshold) {
+      return 'damage-critical';
+    }
+
+    if (value >= damageWarningThreshold) {
+      return 'damage-warning';
+    }
+
+    return '';
+  }
 }

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.ts
@@ -10,6 +10,11 @@ export type { TruckData } from './truck-data';
 const damageWarningThreshold = 25;
 const damageCriticalThreshold = 50;
 
+const rpmGreenZoneStart = 1250;
+const rpmGreenZoneEnd = 2000;
+
+const minutesPerDay = 24 * 60;
+
 
 @Component({
   selector: 'app-truck-display',
@@ -29,9 +34,51 @@ export class TruckDisplayComponent {
   private readonly _store = inject(APP_STORE);
   protected readonly data = this._store.truckData;
 
+  protected readonly rpmGreenZoneStart = rpmGreenZoneStart;
+  protected readonly rpmGreenZoneEnd = rpmGreenZoneEnd;
+
   protected readonly fuelRangeTooShort = computed(() => {
     const data = this.data();
     return data.distanceRemaining > 0 && data.fuelDistance < data.distanceRemaining;
+  });
+
+  protected readonly arrivalTime = computed(() => {
+    const data = this.data();
+    if (data.timeRemaining <= 0) {
+      return '';
+    }
+
+    const minutesOfDay = (data.gameTime + data.timeRemaining) % minutesPerDay;
+    const hours = Math.floor(minutesOfDay / 60);
+    const minutes = minutesOfDay % 60;
+    return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+  });
+
+  protected readonly restBeforeArrival = computed(() => {
+    const data = this.data();
+    return data.restTimeRemaining > 0 && data.timeRemaining > data.restTimeRemaining;
+  });
+
+  protected readonly gearAdvice = computed(() => {
+    const data = this.data();
+    const recommended = data.recommendedGear;
+    return recommended && recommended !== `${data.gear}` ? recommended : '';
+  });
+
+  protected readonly shiftDirection = computed(() => {
+    const data = this.data();
+    const recommended = this.gearAdvice();
+    if (!recommended) {
+      return '';
+    }
+
+    const recommendedGear = Number.parseInt(recommended, 10);
+    const currentGear = Number.parseInt(data.gear, 10);
+    if (Number.isNaN(recommendedGear) || Number.isNaN(currentGear)) {
+      return '';
+    }
+
+    return recommendedGear > currentGear ? 'up' : 'down';
   });
 
   protected damageClass(value: number): string {

--- a/ClientApp/src/app/state/app.store.spec.ts
+++ b/ClientApp/src/app/state/app.store.spec.ts
@@ -33,7 +33,8 @@ describe('MockAppStore', () => {
         jobCargoDamage: 0,
         rpm: 1500,
         rpmMax: 2400,
-        gear: 4,
+        gear: '4',
+        recommendedGear: '',
         speed: 85,
         speedLimit: 90,
         parkingLightsOn: false,
@@ -74,7 +75,7 @@ describe('MockAppStore', () => {
         damageTrailerWheels: 0,
         damageTrailerCargo: 0,
         damageTrailer: 0,
-        gameTime: new Date(),
+        gameTime: 0,
       };
 
       store.updateDisplay({ type: DisplayType.TruckDashboard, data: truckData });

--- a/HaddySimHub.Tests/EtsDataConverterTests.cs
+++ b/HaddySimHub.Tests/EtsDataConverterTests.cs
@@ -121,6 +121,87 @@ namespace HaddySimHub.Tests
             Assert.AreEqual("12", truckData.Gear);
         }
 
+        [TestMethod]
+        public void Convert_RecommendedGear_PicksHigherGearAtCruisingSpeed()
+        {
+            // Arrange - at 20 m/s the lowest-revving drivable gear is closest to the economy target.
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(
+                selectedGear: 2,
+                forwardGearCount: 4,
+                speed: 20,
+                rpmMax: 2500,
+                forwardRatios: [4f, 3f, 2f, 1f],
+                differential: 3f,
+                wheelRadius: 0.5f);
+
+            // Act
+            var truckData = converter.Convert(data).Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual("4", truckData.RecommendedGear);
+        }
+
+        [TestMethod]
+        public void Convert_RecommendedGear_PicksLowerGearAtLowSpeed()
+        {
+            // Arrange - at 8 m/s a lower gear is needed to stay near the economy target.
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(
+                selectedGear: 5,
+                forwardGearCount: 4,
+                speed: 8,
+                rpmMax: 2500,
+                forwardRatios: [4f, 3f, 2f, 1f],
+                differential: 3f,
+                wheelRadius: 0.5f);
+
+            // Act
+            var truckData = converter.Convert(data).Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual("2", truckData.RecommendedGear);
+        }
+
+        [TestMethod]
+        public void Convert_RecommendedGear_EmptyWhenBelowMinimumSpeed()
+        {
+            // Arrange - 2 m/s (7.2 km/h) is below the advice threshold.
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(
+                selectedGear: 1,
+                forwardGearCount: 4,
+                speed: 2,
+                rpmMax: 2500,
+                forwardRatios: [4f, 3f, 2f, 1f],
+                differential: 3f,
+                wheelRadius: 0.5f);
+
+            // Act
+            var truckData = converter.Convert(data).Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual(string.Empty, truckData.RecommendedGear);
+        }
+
+        [TestMethod]
+        public void Convert_RecommendedGear_EmptyWhenTransmissionDataMissing()
+        {
+            // Arrange - no gear ratios, differential or wheel radius available.
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(selectedGear: 3, forwardGearCount: 4, speed: 20, rpmMax: 2500);
+
+            // Act
+            var truckData = converter.Convert(data).Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual(string.Empty, truckData.RecommendedGear);
+        }
+
         #endregion
 
         #region Speed Tests
@@ -858,7 +939,10 @@ namespace HaddySimHub.Tests
             bool cruiseControl = false,
             double cruiseControlSpeed = 0,
             int rpm = 0,
-            int rpmMax = 0)
+            int rpmMax = 0,
+            float[]? forwardRatios = null,
+            float differential = 0,
+            float wheelRadius = 0)
         {
             return new SCSTelemetryBuilder()
                 .WithScale(1f)
@@ -871,6 +955,7 @@ namespace HaddySimHub.Tests
                 .WithWarnings(fuelWarning, adBlueWarning, oilPressureWarning, waterTempWarning, batteryVoltageWarning)
                 .WithLights(parkingLights, lowBeam, highBeam, hazardLights, blinkerLeft, blinkerRight)
                 .WithMotor(selectedGear, parkingBrake, retarderLevel)
+                .WithTransmission(forwardRatios ?? [], differential, wheelRadius)
                 .WithDamage(cabinDamage, engineDamage)
                 .WithControl(throttle)
                 .WithTrailerEmpty()

--- a/HaddySimHub.Tests/SCSTelemetryBuilder.cs
+++ b/HaddySimHub.Tests/SCSTelemetryBuilder.cs
@@ -101,6 +101,14 @@ namespace HaddySimHub.Tests
             return this;
         }
 
+        public SCSTelemetryBuilder WithTransmission(float[] forwardRatios, float differential, float wheelRadius)
+        {
+            _t.TruckValues.ConstantsValues.MotorValues.GearRatiosForward = forwardRatios;
+            _t.TruckValues.ConstantsValues.MotorValues.DifferentialRation = differential;
+            _t.TruckValues.ConstantsValues.WheelsValues.Radius = [wheelRadius];
+            return this;
+        }
+
         public SCSTelemetryBuilder WithDamage(float cabin = 0, float engine = 0)
         {
             _t.TruckValues.CurrentValues.DamageValues.Cabin = cabin;

--- a/HaddySimHub/Displays/ETS/EtsDataConverter.cs
+++ b/HaddySimHub/Displays/ETS/EtsDataConverter.cs
@@ -6,6 +6,9 @@ namespace HaddySimHub.Displays.ETS;
 
 public class EtsDataConverter : IDataConverter<SCSTelemetry, DisplayUpdate>
 {
+    private const float GearAdviceTargetRpm = 1300f;
+    private const float GearAdviceMinSpeedKph = 15f;
+
     private float _fuelAverageConsumption = 0f;
 
     public DisplayUpdate Convert(SCSTelemetry data)
@@ -16,27 +19,11 @@ public class EtsDataConverter : IDataConverter<SCSTelemetry, DisplayUpdate>
             _fuelAverageConsumption = fuelAverageConsumption;
         }
 
-        string gear = string.Empty;
-        int selectedGear = data.TruckValues.CurrentValues.MotorValues.GearValues.Selected;
-        if (selectedGear == 0)
-        {
-            gear = "N";
-        }
-        else if (selectedGear < 0)
-        {
-            gear = "R" + Math.Abs(selectedGear).ToString();
-        }
-        else if (selectedGear > 0)
-        {
-            if (data.TruckValues.ConstantsValues.MotorValues.ForwardGearCount == 14)
-            {
-                gear = selectedGear == 1 ? "C1" : (selectedGear - 2).ToString();
-            }
-            else
-            {
-                gear = selectedGear.ToString();
-            }
-        }
+        uint forwardGearCount = data.TruckValues.ConstantsValues.MotorValues.ForwardGearCount;
+        string gear = FormatGear(data.TruckValues.CurrentValues.MotorValues.GearValues.Selected, forwardGearCount);
+
+        int? recommendedGear = RecommendForwardGear(data);
+        string recommendedGearText = recommendedGear.HasValue ? FormatGear(recommendedGear.Value, forwardGearCount) : string.Empty;
 
         var displayData = new TruckData()
         {
@@ -73,6 +60,7 @@ public class EtsDataConverter : IDataConverter<SCSTelemetry, DisplayUpdate>
 
             // Dashboard
             Gear = gear,
+            RecommendedGear = recommendedGearText,
             Rpm = (int)data.TruckValues.CurrentValues.DashboardValues.RPM,
             RpmMax = (int)data.TruckValues.ConstantsValues.MotorValues.EngineRpmMax,
             Speed = (short)Math.Round(Math.Max(data.TruckValues.CurrentValues.DashboardValues.Speed.Kph, 0)),
@@ -109,5 +97,79 @@ public class EtsDataConverter : IDataConverter<SCSTelemetry, DisplayUpdate>
         };
 
         return new DisplayUpdate { Type = DisplayType.TruckDashboard, Data = displayData };
+    }
+
+    private static string FormatGear(int gear, uint forwardGearCount)
+    {
+        if (gear == 0)
+        {
+            return "N";
+        }
+
+        if (gear < 0)
+        {
+            return "R" + Math.Abs(gear).ToString();
+        }
+
+        if (forwardGearCount == 14)
+        {
+            return gear == 1 ? "C1" : (gear - 2).ToString();
+        }
+
+        return gear.ToString();
+    }
+
+    private static int? RecommendForwardGear(SCSTelemetry data)
+    {
+        var motor = data.TruckValues.ConstantsValues.MotorValues;
+        float[] ratios = motor.GearRatiosForward;
+        float differential = motor.DifferentialRation;
+        float rpmMax = motor.EngineRpmMax;
+        float[] radii = data.TruckValues.ConstantsValues.WheelsValues.Radius;
+
+        if (ratios.Length == 0 || differential <= 0 || rpmMax <= 0 || radii.Length == 0)
+        {
+            return null;
+        }
+
+        float wheelRadius = radii.FirstOrDefault(r => r > 0);
+        if (wheelRadius <= 0)
+        {
+            return null;
+        }
+
+        float speedMps = Math.Abs(data.TruckValues.CurrentValues.DashboardValues.Speed.Value);
+        if (speedMps * 3.6f < GearAdviceMinSpeedKph)
+        {
+            return null;
+        }
+
+        float wheelRevsPerSecond = speedMps / (2f * (float)Math.PI * wheelRadius);
+
+        int bestGear = -1;
+        float bestScore = float.MaxValue;
+        for (int gear = 1; gear <= ratios.Length; gear++)
+        {
+            float ratio = ratios[gear - 1];
+            if (ratio <= 0)
+            {
+                continue;
+            }
+
+            float predictedRpm = wheelRevsPerSecond * 60f * differential * ratio;
+            if (predictedRpm > rpmMax * 0.98f)
+            {
+                continue;
+            }
+
+            float score = Math.Abs(predictedRpm - GearAdviceTargetRpm);
+            if (score < bestScore)
+            {
+                bestScore = score;
+                bestGear = gear;
+            }
+        }
+
+        return bestGear > 0 ? bestGear : null;
     }
 }

--- a/HaddySimHub/Models/TruckData.cs
+++ b/HaddySimHub/Models/TruckData.cs
@@ -129,6 +129,12 @@ public sealed record TruckData
     public required string Gear { get; init; }
 
     /// <summary>
+    /// Gets the gear advised for the current speed to keep the engine in its efficient rev range.
+    /// Empty when no advice is available (e.g. stationary, neutral or missing transmission data).
+    /// </summary>
+    public string RecommendedGear { get; init; } = string.Empty;
+
+    /// <summary>
     /// Gets a value indicating whether cruise control is active.
     /// </summary>
     public bool CruiseControlOn { get; init; }


### PR DESCRIPTION
## Summary

Adds a batch of truck-display improvements plus the supporting backend data.

### Display features
- **Damage severity highlight** — colour-codes the 9 damage values (warning ≥25%, critical ≥50%).
- **Fuel range warning** — flags when the fuel range is shorter than the remaining route distance.
- **Gear advice** — a single direction arrow next to the advised gear (replaces the previous two RPM-zone arrows).
- **Arrival time** — shows estimated arrival as clock time (game time + remaining route time, wrapping past midnight).
- **Rest-stop conflict** — warns when a mandatory rest falls before arrival.

### Backend
- `EtsDataConverter` computes a recommended forward gear from the SCS transmission constants (gear ratios, differential, wheel radius), exposed via `TruckData.RecommendedGear`.
- `gameTime` corrected from `Date` to `number` (in-game minutes).

### Robustness / cleanup
- Truck `gear` typing aligned with race/rally displays (`string`); shift-direction is now safe against non-numeric gears (C1/N/R) — the arrow is hidden rather than pointing the wrong way.
- Removed an unused screenshot spec.

## Verification
- Backend: 209 tests pass.
- Frontend: lint clean, 128 tests pass.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>