### PR TITLE
feat(truck-display): odometer and dashboard backlight

### DIFF
--- a/ClientApp/src/app/displays/truck-display/truck-data.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-data.ts
@@ -70,4 +70,6 @@ export interface TruckData {
   motorBrakeOn: boolean;
   beaconOn: boolean;
   liftAxleIndicatorOn: boolean;
+  odometer: number;
+  dashboardBacklight: number;
 }

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.html
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.html
@@ -88,19 +88,10 @@
         <div class="data-row">
           <div class="data-label">Lading</div>
           @if (data().jobCargoName) {
-            <div class="data-item" id="jobCargoName">{{data().jobCargoName}} ({{data().jobCargoMass | numbernl}} kg)</div>
+            <div class="data-item" id="jobCargoName">{{data().jobCargoName}} ({{data().jobCargoMass | numbernl}} kg) <span id="jobCargoDamage" [class]="damageClass(data().jobCargoDamage)">&middot; {{data().jobCargoDamage}}% schade</span></div>
           }
           @else {
             <div class="data-item" id="jobCargoName">-</div>
-          }
-        </div>
-        <div class="data-row">
-          <div class="data-label">Laadingschade</div>
-          @if (data().jobCargoDamage >= 0) {
-            <div class="data-item" id="jobCargoDamage" [class]="damageClass(data().jobCargoDamage)">{{data().jobCargoDamage}} %</div>
-          }
-          @else {
-            <div class="data-item" id="jobCargoDamage">-</div>
           }
         </div>
       </div>
@@ -132,6 +123,15 @@
             <div class="data-label">Wielen</div>
             <div class="data-item" id="damageTruckWheels" [class]="damageClass(data().damageTruckWheels)">{{data().damageTruckWheels}} %</div>
           </div>
+        </div>
+        <div class="data-row" style="margin-top: 0.8vh">
+          <div class="data-label">Kilometerteller</div>
+          @if (data().odometer > 0) {
+            <div id="odometer" class="data-item">{{data().odometer | numberFlexDigit}} km</div>
+          }
+          @else {
+            <div id="odometer" class="data-item">-</div>
+          }
         </div>
       </div>
     </div>
@@ -193,6 +193,10 @@
         <div class="speed text-center">{{data().speed}}</div>
         <label class="unit text-center">Km/h</label>
         <div class="speed-limit" [class.over-speed-limit]="data().speedLimit && data().speed > data().speedLimit">{{data().speedLimit ? data().speedLimit : '--'}}</div>
+        <div class="cruise-info" [class.hidden]="!data().cruiseControlOn">
+          <img class="dashboard-light" src="/assets/images/cruise-control.png">
+          <span>{{data().cruiseControlSpeed}} km/h</span>
+        </div>
       </div>
     </div>
   </div>
@@ -253,10 +257,6 @@
     </div>
 
     <div class="card lights-card">
-      <div class="icon-text-control" [class.hidden]="!data().cruiseControlOn">
-        <img class="dashboard-light" src="/assets/images/cruise-control.png">
-        <div>{{data().cruiseControlSpeed}} km/h</div>
-      </div>
       <div class="icon-text-control" id="batteryVoltage">
         <img class="dashboard-light" src="/assets/images/battery.svg" [class.filter-red]="data().batteryVoltageWarningOn">
         <div>{{data().batteryVoltage | number: '1.1-1'}} V</div>

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.scss
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.scss
@@ -7,6 +7,7 @@ app-truck-display {
   font-family: Poppins, sans-serif;
   color: white;
   background: radial-gradient(ellipse at 50% 30%, #252840 0%, #1e1e2f 70%);
+  filter: brightness(var(--dashboard-brightness, 1));
 
   .top-cards {
     display: grid;
@@ -198,6 +199,24 @@ app-truck-display {
     justify-content: center;
     height: 100%;
     width: 100%;
+  }
+
+  .cruise-info {
+    display: flex;
+    align-items: center;
+    gap: 0.5vh;
+    margin-top: 0.8vh;
+
+    img {
+      width: clamp(1.5rem, 2.5vh, 2.5rem);
+      height: auto;
+    }
+
+    span {
+      font-size: clamp(0.85rem, 2vh, 1.6rem);
+      font-weight: 600;
+      color: #2ecc71;
+    }
   }
 
   app-gauge {

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.spec.ts
@@ -84,9 +84,9 @@ describe('TruckDisplayComponent', () => {
     });
 
     it('Cargo name is shown', async () => {
-      patchData({ jobCargoName: 'Helicopter', jobCargoMass: 2500 });
+      patchData({ jobCargoName: 'Helicopter', jobCargoMass: 2500, jobCargoDamage: 0 });
 
-      expect(await harness.getElementText('#jobCargoName')).toEqual('Helicopter (2.500 kg)');
+      expect(await harness.getElementText('#jobCargoName')).toEqual('Helicopter (2.500 kg) · 0% schade');
     });
   });
 

--- a/ClientApp/src/app/displays/truck-display/truck-display.component.ts
+++ b/ClientApp/src/app/displays/truck-display/truck-display.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, ViewEncapsulation } from '@angular/core';
+import { Component, computed, effect, ElementRef, inject, ViewEncapsulation } from '@angular/core';
 import { DecimalPipe } from '@angular/common';
 import { WaypointComponent } from './waypoint.component';
 import { TimespanPipe, NumberNlPipe, NumberFlexDigitPipe } from '../../shared';
@@ -32,7 +32,25 @@ const minutesPerDay = 24 * 60;
 })
 export class TruckDisplayComponent {
   private readonly _store = inject(APP_STORE);
+  private readonly _elementRef = inject(ElementRef);
   protected readonly data = this._store.truckData;
+
+  private static readonly _minBrightness = 0.3;
+
+  protected readonly dashboardBrightness = computed(() => {
+    const backlight = this.data().dashboardBacklight;
+    if (!backlight || backlight <= 0) {
+      return TruckDisplayComponent._minBrightness;
+    }
+    return Math.max(TruckDisplayComponent._minBrightness, Math.min(backlight, 1));
+  });
+
+  public constructor() {
+    effect(() => {
+      const el = this._elementRef.nativeElement as HTMLElement;
+      el.style.setProperty('--dashboard-brightness', `${this.dashboardBrightness()}`);
+    });
+  }
 
   protected readonly rpmGreenZoneStart = rpmGreenZoneStart;
   protected readonly rpmGreenZoneEnd = rpmGreenZoneEnd;

--- a/ClientApp/src/app/state/app.store.spec.ts
+++ b/ClientApp/src/app/state/app.store.spec.ts
@@ -86,6 +86,8 @@ describe('MockAppStore', () => {
         liftAxleIndicatorOn: false,
         brakeTemp: 120,
         brakeAirPressure: 120,
+        odometer: 142537,
+        dashboardBacklight: 0.75,
       };
 
       store.updateDisplay({ type: DisplayType.TruckDashboard, data: truckData });

--- a/HaddySimHub.Tests/EtsDataConverterTests.cs
+++ b/HaddySimHub.Tests/EtsDataConverterTests.cs
@@ -895,6 +895,62 @@ namespace HaddySimHub.Tests
 
         #endregion
 
+        #region Odometer Tests
+
+        [TestMethod]
+        public void Convert_Odometer()
+        {
+            // Arrange
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(odometer: 123456.7f);
+
+            // Act
+            var update = converter.Convert(data);
+            var truckData = update.Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual(123456.7f, truckData.Odometer);
+        }
+
+        #endregion
+
+        #region Dashboard Backlight Tests
+
+        [TestMethod]
+        public void Convert_DashboardBacklight()
+        {
+            // Arrange
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry(dashboardBacklight: 0.75f);
+
+            // Act
+            var update = converter.Convert(data);
+            var truckData = update.Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual(0.75f, truckData.DashboardBacklight);
+        }
+
+        [TestMethod]
+        public void Convert_DashboardBacklight_DefaultZero()
+        {
+            // Arrange
+            var converter = new EtsDataConverter();
+            var data = CreateMockTelemetry();
+
+            // Act
+            var update = converter.Convert(data);
+            var truckData = update.Data as TruckData;
+
+            // Assert
+            Assert.IsNotNull(truckData);
+            Assert.AreEqual(0f, truckData.DashboardBacklight);
+        }
+
+        #endregion
+
         #region Helper Methods
 
         private SCSTelemetry CreateMockTelemetry(
@@ -942,7 +998,9 @@ namespace HaddySimHub.Tests
             int rpmMax = 0,
             float[]? forwardRatios = null,
             float differential = 0,
-            float wheelRadius = 0)
+            float wheelRadius = 0,
+            float odometer = 0,
+            float dashboardBacklight = 0)
         {
             return new SCSTelemetryBuilder()
                 .WithScale(1f)
@@ -951,9 +1009,10 @@ namespace HaddySimHub.Tests
                 .WithNavigation(navDistance, navTime, speedLimit)
                 .WithJob(sourceCity, sourceCompany, destCity, destCompany, jobIncome, cargoMass, cargoDamage)
                 .WithTruckConstants(forwardGearCount: forwardGearCount, engineRpmMax: rpmMax, retarderStepCount: retarderStepCount)
-                .WithDashboard(speed: speed, cruiseControl: cruiseControl, cruiseSpeed: cruiseControlSpeed, fuelAvg: fuelAverageConsumption, fuelAmount: fuelAmount, fuelRange: fuelDistance, oilPressure: oilPressure, oilTemp: oilTemp, waterTemp: waterTemp, batteryVoltage: batteryVoltage, rpm: rpm)
+                .WithDashboard(speed: speed, cruiseControl: cruiseControl, cruiseSpeed: cruiseControlSpeed, fuelAvg: fuelAverageConsumption, fuelAmount: fuelAmount, fuelRange: fuelDistance, oilPressure: oilPressure, oilTemp: oilTemp, waterTemp: waterTemp, batteryVoltage: batteryVoltage, rpm: rpm, odometer: odometer)
                 .WithWarnings(fuelWarning, adBlueWarning, oilPressureWarning, waterTempWarning, batteryVoltageWarning)
                 .WithLights(parkingLights, lowBeam, highBeam, hazardLights, blinkerLeft, blinkerRight)
+                .WithDashboardBacklight(dashboardBacklight)
                 .WithMotor(selectedGear, parkingBrake, retarderLevel)
                 .WithTransmission(forwardRatios ?? [], differential, wheelRadius)
                 .WithDamage(cabinDamage, engineDamage)

--- a/HaddySimHub.Tests/SCSTelemetryBuilder.cs
+++ b/HaddySimHub.Tests/SCSTelemetryBuilder.cs
@@ -55,7 +55,7 @@ namespace HaddySimHub.Tests
             return this;
         }
 
-        public SCSTelemetryBuilder WithDashboard(double speed = 0, bool cruiseControl = false, double cruiseSpeed = 0, float fuelAvg = 0, float fuelAmount = 0, float fuelRange = 0, float adBlue = 0, float oilPressure = 0, float oilTemp = 0, float waterTemp = 0, float batteryVoltage = 0, int rpm = 0)
+        public SCSTelemetryBuilder WithDashboard(double speed = 0, bool cruiseControl = false, double cruiseSpeed = 0, float fuelAvg = 0, float fuelAmount = 0, float fuelRange = 0, float adBlue = 0, float oilPressure = 0, float oilTemp = 0, float waterTemp = 0, float batteryVoltage = 0, int rpm = 0, float odometer = 0)
         {
             _t.TruckValues.CurrentValues.DashboardValues.Speed.Value = (float)speed;
             _t.TruckValues.CurrentValues.DashboardValues.CruiseControl = cruiseControl;
@@ -69,6 +69,13 @@ namespace HaddySimHub.Tests
             _t.TruckValues.CurrentValues.DashboardValues.WaterTemperature = waterTemp;
             _t.TruckValues.CurrentValues.DashboardValues.BatteryVoltage = batteryVoltage;
             _t.TruckValues.CurrentValues.DashboardValues.RPM = rpm;
+            _t.TruckValues.CurrentValues.DashboardValues.Odometer = odometer;
+            return this;
+        }
+
+        public SCSTelemetryBuilder WithDashboardBacklight(float backlight)
+        {
+            _t.TruckValues.CurrentValues.LightsValues.DashboardBacklight = backlight;
             return this;
         }
 

--- a/HaddySimHub/Displays/ETS/EtsDataConverter.cs
+++ b/HaddySimHub/Displays/ETS/EtsDataConverter.cs
@@ -104,6 +104,8 @@ public class EtsDataConverter : IDataConverter<SCSTelemetry, DisplayUpdate>
             LiftAxleIndicatorOn = data.TruckValues.CurrentValues.LiftAxleIndicator,
             RetarderLevel = data.TruckValues.CurrentValues.MotorValues.BrakeValues.RetarderLevel,
             RetarderStepCount = data.TruckValues.ConstantsValues.MotorValues.RetarderStepCount,
+            Odometer = data.TruckValues.CurrentValues.DashboardValues.Odometer,
+            DashboardBacklight = data.TruckValues.CurrentValues.LightsValues.DashboardBacklight,
         };
 
         return new DisplayUpdate { Type = DisplayType.TruckDashboard, Data = displayData };

--- a/HaddySimHub/Displays/ETS/TestDisplay.cs
+++ b/HaddySimHub/Displays/ETS/TestDisplay.cs
@@ -9,6 +9,8 @@ namespace HaddySimHub.Displays.ETS
         private const int RpmMax = 3000;
         private const int RpmStep = 100;
         private int _currentRpm = 0;
+        private int _cruiseTick = 0;
+        private bool _cruiseOn = false;
 
         public TestDisplay(
             string id,
@@ -26,7 +28,7 @@ namespace HaddySimHub.Displays.ETS
                 _currentRpm = 0;
             }
 
-            var speed = (short)(_currentRpm * 0.08);
+            var speed = (short)(82 + Math.Sin(_currentRpm * 2 * Math.PI / RpmMax) * 5);
             var recommendedGear = _currentRpm switch
             {
                 > 2000 => "6",
@@ -34,11 +36,42 @@ namespace HaddySimHub.Displays.ETS
                 _ => string.Empty,
             };
 
+            var backlight = (float)(0.65 + 0.35 * Math.Sin(_currentRpm * 2 * Math.PI / RpmMax));
+
+            _cruiseTick++;
+            if (_cruiseTick >= 30)
+            {
+                _cruiseTick = 0;
+                _cruiseOn = !_cruiseOn;
+            }
+
             return new DisplayUpdate
             {
                 Type = DisplayType.TruckDashboard,
                 Data = new TruckData
                 {
+                    // Route card
+                    SourceCity = "Berlin",
+                    SourceCompany = "Trisan",
+                    DestinationCity = "München",
+                    DestinationCompany = "LKW Logistics",
+                    DistanceRemaining = 587,
+                    TimeRemaining = 420,
+                    TimeRemainingIrl = 42,
+                    RestTimeRemaining = 360,
+                    RestTimeRemainingIrl = 36,
+                    GameTime = 13 * 60 + 45,
+
+                    // Job card
+                    TruckName = "Volvo FH16",
+                    JobTimeRemaining = 720,
+                    JobTimeRemainingIrl = 72,
+                    JobIncome = 18750,
+                    JobCargoName = "Helicopter",
+                    JobCargoMass = 12500,
+                    JobCargoDamage = 3,
+
+                    // Dashboard
                     Speed = speed,
                     Gear = "5",
                     RecommendedGear = recommendedGear,
@@ -51,9 +84,59 @@ namespace HaddySimHub.Displays.ETS
                     AdBlueAmount = 60,
                     AdBlueCapacity = 80,
                     SpeedLimit = 80,
+                    CruiseControlOn = _cruiseOn,
+                    CruiseControlSpeed = 82,
                     EngineOn = true,
+                    Throttle = 45,
+                    DifferentialLock = false,
+
+                    // Truck damage
+                    DamageTruckEngine = 2,
+                    DamageTruckTransmission = 8,
+                    DamageTruckCabin = 0,
+                    DamageTruckChassis = 12,
+                    DamageTruckWheels = 5,
+
+                    // Trailer
+                    NumberOfTrailersAttached = 1,
+                    DamageTrailerChassis = 4,
+                    DamageTrailerBody = 1,
+                    DamageTrailerWheels = 7,
+                    DamageTrailerCargo = 3,
+
+                    // Gauges & controls
                     BrakeTemp = 120,
                     BrakeAirPressure = 120,
+                    OilPressure = 45.2f,
+                    OilTemp = 92.5f,
+                    WaterTemp = 87.1f,
+                    BatteryVoltage = 24.6f,
+                    RetarderLevel = 0,
+                    RetarderStepCount = 4,
+
+                    // Lights
+                    ParkingLightsOn = true,
+                    LowBeamOn = true,
+                    HighBeamOn = false,
+                    BlinkerLeftOn = true,
+                    BlinkerRightOn = false,
+                    HazardLightsOn = false,
+                    ParkingBrakeOn = false,
+                    WipersOn = false,
+                    MotorBrakeOn = false,
+                    BeaconOn = false,
+                    LiftAxleIndicatorOn = false,
+                    FuelWarningOn = false,
+                    AdBlueWarningOn = false,
+                    AirPressureWarningOn = false,
+                    AirPressureEmergencyOn = false,
+                    BatteryVoltageWarningOn = false,
+                    WaterTempWarningOn = false,
+                    OilPressureWarningOn = false,
+
+                    // Extra
+                    Odometer = 142537,
+                    DashboardBacklight = backlight,
                 }
             };
         }

--- a/HaddySimHub/Models/TruckData.cs
+++ b/HaddySimHub/Models/TruckData.cs
@@ -243,4 +243,14 @@ public sealed record TruckData
     public bool LiftAxleIndicatorOn { get; init; }
     public uint RetarderLevel { get; init; }
     public uint RetarderStepCount { get; init; }
+
+    /// <summary>
+    /// Total distance traveled (km).
+    /// </summary>
+    public float Odometer { get; init; }
+
+    /// <summary>
+    /// Dashboard backlight intensity (0.0 = dark, 1.0 = full brightness).
+    /// </summary>
+    public float DashboardBacklight { get; init; }
 }


### PR DESCRIPTION
**Odometer** — totale km-stand toegevoegd in de Truck schade card.

**Dashboard backlight** — de UI dimt mee met de in-game dashboard verlichting via `--dashboard-brightness` CSS custom property.

**Laadingschade** — inline met de cargo beschrijving (zelfde regel).

**Cruise control** — verplaatst naar de snelheid card, onderaan gecentreerd. Ruimte wordt gereserveerd via `visibility: hidden` om layout-verspringen te voorkomen.

**TestDisplay** — uitgebreid met realistische testdata voor alle bovenste cards + backlight demo (oscilleert 0.3-1.0) + cruise control die elke ~3s togglet.