### PR TITLE
feat(race-display): reorganize layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,22 @@ Then `dotnet build` will use the correct SDK version.
 - Logging is excluded from HaddySimHub project (see Logging/** excludes in csproj)
 - **Game display pipeline**: every supported game follows a `provider → converter → display → hub` pattern, registered via `RegisterGameDisplay<>` in `Extensions/ApplicationCompositionExtensions.cs`. See [`HaddySimHub/Displays/README.md`](./HaddySimHub/Displays/README.md) for the full convention and how to add a new game.
 - **Console dashboard**: in an interactive terminal the backend renders a live Spectre.Console TUI (`HaddySimHub/Dashboard/`); console logs are routed into it via `DashboardLogTarget` instead of being written directly. Set `HADDYSIMHUB_NO_DASHBOARD=1` to fall back to plain coloured console logging (this also happens automatically when stdout/stdin is redirected, e.g. in CI). Set `HADDYSIMHUB_DEBUG=1` for debug-level logging plus per-frame data logs.
+- **Test mode**: the backend supports `--test <name>` to serve fake telemetry data without a real game running. Test displays are registered in `Extensions/ApplicationCompositionExtensions.cs` via `RegisterTestDisplay<>`. Available test IDs: `race`, `rally`, `truck`. Usage:
+  ```bash
+  # From ClientApp/ directory — starts both frontend + backend:
+  npm run dev:all:race                # circuit racing data (iRacing-style)
+  npm run dev:all:rally               # rally stage data (Dirt Rally 2-style)
+  npm run dev:all:truck               # trucking data (ETS2-style)
+  ```
+  Or manually in two terminals:
+  ```bash
+  # Terminal 1 — frontend
+  npm start                           # from ClientApp/
+
+  # Terminal 2 — backend (race test data)
+  HADDYSIMHUB_NO_DASHBOARD=1 dotnet run --project HaddySimHub -- --test race --no-update
+  ```
+  Then open http://localhost:4200/ to see the display live. Press `Ctrl+T` while the backend is running to cycle test modes (`"" → race → rally → truck → ""`).
 - **Backend tests use MSTest**: assert exceptions with `Assert.Throws<T>()`, `Assert.ThrowsExactly<T>()`, or `Assert.ThrowsAsync<T>()`. The legacy `Assert.ThrowsException<T>()` does **not** exist in this MSTest version and will fail to compile.
 
 ## Do Not

--- a/ClientApp/src/app/displays/race-display/race-data.ts
+++ b/ClientApp/src/app/displays/race-display/race-data.ts
@@ -17,6 +17,7 @@ export interface RaceData {
   fuelAvgLap?: number; // not exposed by all sims
   fuelLastLap?: number; // not exposed by all sims
   fuelEstLaps: number;
+  currentLapTime: number;
   lastLapTime: number;
   lastLapTimeDelta?: number; // not exposed by all sims
   bestLapTime?: number; // not exposed by all sims

--- a/ClientApp/src/app/displays/race-display/race-display.component.html
+++ b/ClientApp/src/app/displays/race-display/race-display.component.html
@@ -1,175 +1,150 @@
 <div class="dashboard-container">
-  <div class="dashboard-row cols-3">
-    <div class="group-border border-blue">
-      <div class="dashboard-row cols-2">
-        <div class="data-item">
-          <label>Session Type</label>
-          <div>{{data().sessionType}}</div>
-        </div>
-        @if (data().strengthOfField !== undefined) {
-          <div class="data-item">
-            <label>SOF</label>
-            <div>{{data().strengthOfField}}</div>
-          </div>
-        }
-      </div>
-      <div class="dashboard-row cols-2">
-        <div class="data-item">
-          <label>Air</label>
-          <div id="air-temp">{{data().airTemp |number:'1.1-1':'en-US'}} &deg;C</div>
-        </div>
-        <div class="data-item">
-          <label>Track</label>
-          <div id="track-temp">{{data().trackTemp |number:'1.1-1':'en-US'}} &deg;C</div>
-        </div>
-      </div>
-      <div class="dashboard-row cols-2">
-        <div class="data-item">
-        <label>Lap</label>
-            @if (data().isLimitedTime && !data().isLimitedSessionLaps) {
-                <div id="laps">{{data().currentLap}}</div>
-            } @else if (data().totalLaps > 0) {
-                <div id="laps">{{data().currentLap}}/{{data().totalLaps}}</div>
-            } @else {
-                <div id="laps">{{data().currentLap}}</div>
-            }
-        </div>
-        <div class="data-item">
-          <label>Time remaining</label>
-          <div>{{data().sessionTimeRemaining | time}}</div>
-        </div>
-      </div>
-      <div class="dashboard-row cols-2">
-        @if (data().position !== undefined) {
-          <div class="data-item">
-            <label>Position</label>
-            <div id="position">{{data().position}}</div>
-          </div>
-        }
-
-        @if (data().incidents !== undefined && data().maxIncidents !== undefined) {
-          <div class="data-item">
-              <label>Incidents</label>
-              @if (data().maxIncidents === 999) {
-                  <div id="incidents">{{data().incidents}}</div>
-              } @else {
-                  <div id="incidents">{{data().incidents}}/{{data().maxIncidents}}</div>
-              }
-          </div>
-        }
-      </div>
-
-      @if (data().irating !== undefined || data().safetyRating !== undefined) {
-        <div class="dashboard-row cols-2">
-          @if (data().irating !== undefined) {
-            <div class="data-item">
-              <label>iRating</label>
-              <div id="irating">{{data().irating | irating}}</div>
-            </div>
-          }
-          @if (data().safetyRating !== undefined) {
-            <div class="data-item">
-              <label>Safety Rating</label>
-              <div id="safetyRating">{{data().safetyRating}}</div>
-            </div>
-          }
-        </div>
-      }
+  <div class="top-bar">
+    <div class="top-bar-item">
+      <label>Session</label>
+      <span>{{data().sessionType}}</span>
     </div>
-    <div class=" group-border border-yellow speedometer" [class.max-rpm]="data().rpm >= data().rpmMax">
-      <app-speedometer [rpm]="data().rpm" [gear]="data().gear" [speed]="data().speed" />
-    </div>
-    <div class="group-border border-blue">
-      <div class="dashboard-row cols-2">
-          @if (data().fuelLastLap !== undefined) {
-            <div class="data-item">
-                <label>Fuel last lap</label>
-                <div id="fuelLastLap">{{data().fuelLastLap |number:'1.1-1':'en-US'}} L</div>
-            </div>
-          }
-
-          @if (data().fuelAvgLap !== undefined) {
-            <div class="data-item">
-                <label>Fuel avg lap</label>
-                <div id="fuelAvgLap">{{data().fuelAvgLap |number:'1.1-1':'en-US'}} L</div>
-            </div>
-          }
-      </div>
-
-      <div class="dashboard-row cols-2">
-        @if (data().fuelRemaining !== undefined) {
-          <div class="data-item">
-            <label>Fuel remaining</label>
-            <div id="fuelRemaining">{{data().fuelRemaining |number:'1.1-1':'en-US'}} L</div>
-          </div>
-        }
-    
-        <div class="data-item">
-          <label>Fuel est. laps</label>
-          <div id="fuelEstLaps" [class.text-red]="data().totalLaps > 0 && ((data().totalLaps - data().currentLap) > data().fuelEstLaps)">{{data().fuelEstLaps |number:'1.1-1':'en-US'}}</div>
-        </div>
-      </div>
-
-      @if (data().expectedPosition !== undefined) {
-        <div class="dashboard-row">
-          <div class="data-item">
-            <label>Expected position</label>
-            <div id="expectedPosition">{{data().expectedPosition}}</div>
-          </div>
-        </div>
-      }
-    </div>
-  </div>
-  <div class="dashboard-row cols-3">
-    <div class="group-border border-blue">
-      <div class="dashboard-row cols-2">
-          <div class="data-item">
-              <label>Last laptime</label>
-              <div class="last-laptime" id="lastLapTime">{{data().lastLapTime | laptime}}</div>
-          </div>
-          @let lastDelta = data().lastLapTimeDelta;
-          @if (lastDelta !== undefined) {
-            <div class="data-item">
-                <label>Delta</label>
-                <div id="lastLapTimeDelta" [class.text-green]="lastDelta < 0" [class.text-red]="lastDelta > 0">{{lastDelta | deltatime}}</div>
-            </div>
-          }
-      </div>
-    </div>
-
-    @if (data().brakeBias !== undefined) {
-      <div class="group-border border-blue">
-          <div class="dashboard-row">
-              <div class="data-item brake-bias-item">
-                <label>Brake bias</label>
-                <div id="brakeBias">{{data().brakeBias |number:'1.1-1':'en-US'}}</div>
-              </div>
-          </div>
+    @if (data().strengthOfField !== undefined && data().strengthOfField !== null) {
+      <div class="top-bar-item">
+        <label>SOF</label>
+        <span>{{data().strengthOfField}}</span>
       </div>
     }
-
-    <div class="group-border border-blue">
-      <div class="dashboard-row cols-2">
-          @let bestLap = data().bestLapTime;
-          @if (bestLap !== undefined) {
-            <div class="data-item">
-                <label>Best laptime</label>
-                <div class="best-laptime" id="bestLapTime">{{bestLap | laptime}}</div>
-            </div>
-          }
-          @let bestDelta = data().bestLapTimeDelta;
-          @if (bestDelta !== undefined) {
-            <div class="data-item">
-                <label>Delta</label>
-                <div id="bestLapTimeDelta" [class.text-green]="bestDelta < 0" [class.text-red]="bestDelta > 0">{{bestDelta | deltatime}}</div>
-            </div>
-          }
+    @if (data().safetyRating !== undefined && data().safetyRating !== null) {
+      <div class="top-bar-item">
+        <label>Safety Rating</label>
+        <span id="safetyRating">{{data().safetyRating}}</span>
       </div>
+    }
+    <div class="top-bar-item">
+      <label>Time left</label>
+      <span>{{data().sessionTimeRemaining | time}}</span>
+    </div>
+    <div class="top-bar-item">
+      <label>Air</label>
+      <span id="air-temp">{{data().airTemp |number:'1.1-1':'en-US'}}&deg;</span>
+    </div>
+    <div class="top-bar-item">
+      <label>Track</label>
+      <span id="track-temp">{{data().trackTemp |number:'1.1-1':'en-US'}}&deg;</span>
     </div>
   </div>
-  <app-telemetry-trace [telemetrySample]="telemetrySample" />
+
+  <div class="main-area">
+    <div class="main-grid">
+      <div class="panel info-panel">
+        @if (data().incidents !== undefined) {
+          <div class="info-row">
+            <label>Incidents</label>
+            @if (data().maxIncidents !== undefined && data().maxIncidents !== 999) {
+              <span id="incidents">{{data().incidents}}/{{data().maxIncidents}}</span>
+            } @else {
+              <span id="incidents">{{data().incidents}}</span>
+            }
+          </div>
+        }
+        @if (data().irating !== undefined) {
+          <div class="info-row">
+            <label>iR</label>
+            <span id="irating">{{data().irating | irating}}</span>
+          </div>
+        }
+        @if (data().position !== undefined) {
+          <div class="info-row">
+            <label>Pos</label>
+            <span id="position" class="text-accent">P{{data().position}}</span>
+          </div>
+        }
+        @if (data().expectedPosition !== undefined) {
+          <div class="info-row">
+            <label>Expected pos</label>
+            <span id="expectedPosition" class="text-accent">P{{data().expectedPosition}}</span>
+          </div>
+        }
+        <div class="info-row">
+          <label>Lap</label>
+          @if (data().isLimitedTime && !data().isLimitedSessionLaps) {
+            <span id="laps">{{data().currentLap}}</span>
+          } @else if (data().totalLaps > 0) {
+            <span id="laps">{{data().currentLap}}/{{data().totalLaps}}</span>
+          } @else {
+            <span id="laps">{{data().currentLap}}</span>
+          }
+        </div>
+        @if (data().currentLapTime) {
+          <div class="lap-row">
+            <label>Current lap</label>
+            <span class="lap-values">
+              <span class="lap-value" id="currentLapTime">{{data().currentLapTime | laptime}}</span>
+              <span class="delta-value delta-placeholder"></span>
+            </span>
+          </div>
+        }
+        <div class="lap-row">
+          <label>Last lap</label>
+          <span class="lap-values">
+            <span class="lap-value" id="lastLapTime">{{data().lastLapTime | laptime}}</span>
+            @let lastDelta = data().lastLapTimeDelta;
+            @if (lastDelta !== undefined) {
+              <span class="delta-value" id="lastLapTimeDelta" [class.text-positive]="lastDelta < 0" [class.text-negative]="lastDelta > 0">{{lastDelta | deltatime}}</span>
+            }
+          </span>
+        </div>
+        @let bestLap = data().bestLapTime;
+        @if (bestLap !== undefined) {
+          <div class="lap-row">
+            <label>Best lap</label>
+            <span class="lap-values">
+              <span class="lap-value best" id="bestLapTime">{{bestLap | laptime}}</span>
+              @let bestDelta = data().bestLapTimeDelta;
+              @if (bestDelta !== undefined) {
+                <span class="delta-value" id="bestLapTimeDelta" [class.text-positive]="bestDelta < 0" [class.text-negative]="bestDelta > 0">{{bestDelta | deltatime}}</span>
+              }
+            </span>
+          </div>
+        }
+      </div>
+
+      <div class="panel speedometer-panel" [class.max-rpm]="data().rpm >= data().rpmMax">
+        <app-speedometer [rpm]="data().rpm" [gear]="data().gear" [speed]="data().speed" />
+      </div>
+
+      <div class="panel fuel-panel">
+        @if (data().fuelRemaining !== undefined) {
+          <div class="fuel-primary">
+            <label>Fuel</label>
+            <span id="fuelRemaining">{{data().fuelRemaining |number:'1.1-1':'en-US'}}<small>L</small></span>
+          </div>
+        }
+        <div class="info-row">
+          <label>Est. laps</label>
+          <span id="fuelEstLaps" [class.text-danger]="data().totalLaps > 0 && ((data().totalLaps - data().currentLap) > data().fuelEstLaps)">{{data().fuelEstLaps |number:'1.1-1':'en-US'}}</span>
+        </div>
+        @if (data().fuelLastLap !== undefined) {
+          <div class="info-row">
+            <label>Last lap</label>
+            <span id="fuelLastLap">{{data().fuelLastLap |number:'1.1-1':'en-US'}}L</span>
+          </div>
+        }
+        @if (data().fuelAvgLap !== undefined) {
+          <div class="info-row">
+            <label>Avg lap</label>
+            <span id="fuelAvgLap">{{data().fuelAvgLap |number:'1.1-1':'en-US'}}L</span>
+          </div>
+        }
+        @if (data().brakeBias !== undefined) {
+          <div class="fuel-primary">
+            <label>Brake bias</label>
+            <span id="brakeBias">{{data().brakeBias |number:'1.1-1':'en-US'}}<small>%</small></span>
+          </div>
+        }
+      </div>
+    </div>
+
+    <app-telemetry-trace [telemetrySample]="telemetrySample" />
+  </div>
 </div>
 
 @if (data().pitLimiterOn) {
-  <div class="pit-limiter blink-text">Pit Limiter</div>
+  <div class="pit-limiter">PIT LIMITER</div>
 }

--- a/ClientApp/src/app/displays/race-display/race-display.component.scss
+++ b/ClientApp/src/app/displays/race-display/race-display.component.scss
@@ -1,214 +1,252 @@
 app-race-display {
+  --panel-bg: rgb(255 255 255 / 4%);
+  --panel-border: rgb(255 255 255 / 8%);
+  --label-color: rgb(180 190 210 / 70%);
+  --accent: #4fc3f7;
+  --positive: #4caf50;
+  --negative: #ef5350;
+  --danger: #ff5722;
+  --warning: #ffc107;
+
   height: 100%;
+  font-variant-numeric: tabular-nums;
 
   .dashboard-container {
     display: grid;
-    grid-template-rows: auto auto auto 1fr;
-    gap: 1.2vh;
-    color: white;
-    font-size: clamp(1.2rem, 3.2vh, 2rem);
+    grid-template-rows: auto 1fr;
+    gap: 0.8vh;
     height: 100%;
-  }
-
-  .dashboard-row {
-    display: grid;
-    gap: 1vh;
-    width: calc(100% - 1.2vh);
-    margin-left: 0.6vh;
-
-    &.cols-2 {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    &.cols-3 {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  .speedometer {
-    display: flex;
-    flex-direction: column;
-
-    &.max-rpm {
-      background-color: red;
-    }
-  }
-
-  app-speedometer {
-    * {
-      color: white;
-    }
-
-    label {
-      text-transform: uppercase;
-      text-align: center;
-      width: 100%;
-      font-size: clamp(0.9rem, 2vh, 1.2rem);
-    }
-
-    .rpm, .speed {
-      font-size: clamp(1.5rem, 3.2vh, 2.5rem);
-    }
-
-    .gear {
-      text-align: center;
-      font-size: clamp(2.5rem, 6vh, 5rem);
-    }
+    padding: 0.8vh;
+    box-sizing: border-box;
   }
 
   label {
     text-transform: uppercase;
-    font-size: clamp(0.8rem, 1.8vh, 1.1rem);
-    text-align: right;
-    color: gold;
+    font-size: clamp(0.65rem, 1.4vh, 0.85rem);
+    color: var(--label-color);
+    letter-spacing: 0.05em;
+    font-weight: 500;
   }
 
-  .text-center {
-    text-align: center;
-  }
+  .text-positive { color: var(--positive); }
+  .text-negative { color: var(--negative); }
+  .text-danger { color: var(--danger); }
+  .text-accent { color: var(--accent); }
 
-  .best-laptime {
-    color: purple;
-  }
+  /* ─── Top bar ─── */
+  .top-bar {
+    display: flex;
+    justify-content: space-evenly;
+    gap: 2vh;
+    padding: 0.8vh 1.4vh;
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 1vh;
+    align-items: center;
+    backdrop-filter: blur(8px);
 
-  .group-border {
-    border: white 0.3vh solid;
-    padding: 1vh 1.4vh;
-    border-radius: 1.4vh;
-    height: 100%;
+    .top-bar-item {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2vh;
 
-    &.border-blue {
-      border-color: rgb(0 0 255 / 55.5%);
+      > span {
+        font-size: clamp(0.95rem, 2vh, 1.4rem);
+        font-weight: 600;
+        color: #fff;
+      }
     }
-
-    &.border-yellow {
-      border-color: yellow;
-    }
-
-    &:has(.flag) {
-      padding: 0;
-      margin: 0;
-      overflow: hidden;
-    }
   }
 
-  .center-column {
+  /* ─── Main area (panels + telemetry) ─── */
+  .main-area {
     display: grid;
-    grid-template-rows: 8fr 2fr;
-    gap: 1vh;
+    grid-template-rows: 3fr 2fr;
+    gap: 0.8vh;
+    min-height: 0;
   }
 
-  .hidden {
-    visibility: hidden;
+  /* ─── Main 3-column grid ─── */
+  .main-grid {
+    display: grid;
+    grid-template-columns: 1fr 2fr 1fr;
+    gap: 0.8vh;
+    min-height: 0;
   }
 
-  .text-red {
-    color: red;
+  .panel {
+    background: var(--panel-bg);
+    border: 1px solid var(--panel-border);
+    border-radius: 1.2vh;
+    padding: 1.2vh 1.4vh;
+    backdrop-filter: blur(8px);
+    display: flex;
+    flex-direction: column;
+    gap: 0.4vh;
+    transition: border-color 0.3s, background 0.3s;
   }
 
-  .text-green {
-    color: green;
+  /* ─── Left info panel ─── */
+  .info-panel {
+    justify-content: center;
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.15vh 0;
+
+      > span {
+        font-size: clamp(0.95rem, 2vh, 1.3rem);
+        font-weight: 500;
+        color: #fff;
+      }
+    }
   }
 
-  .brake-bias-item {
-    margin-left: auto;
-    margin-right: auto;
+  .lap-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.6vh;
+    align-items: baseline;
+    padding: 0.15vh 0;
+    border-top: 1px solid rgb(255 255 255 / 6%);
+    margin-top: 0.3vh;
+    padding-top: 0.5vh;
+
+    .lap-values {
+      display: flex;
+      align-items: baseline;
+      gap: 0.6vh;
+      justify-content: flex-end;
+    }
+
+    .lap-value {
+      font-size: clamp(1rem, 2.2vh, 1.5rem);
+      font-weight: 600;
+      color: #fff;
+
+      &.best {
+        color: #ce93d8;
+      }
+    }
+
+    .delta-value {
+      font-size: clamp(0.8rem, 1.6vh, 1.1rem);
+      font-weight: 600;
+      min-width: 7ch;
+    }
+
+    .delta-placeholder {
+      visibility: hidden;
+    }
   }
 
+  /* ─── Center speedometer ─── */
+  .speedometer-panel {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.6vh 1.4vh;
+
+    &.max-rpm {
+      border-color: var(--danger);
+      background: rgb(255 50 0 / 10%);
+      box-shadow: 0 0 3vh rgb(255 50 0 / 15%);
+    }
+
+    app-speedometer {
+      text-align: center;
+      width: 100%;
+
+      > label {
+        text-transform: uppercase;
+        font-size: clamp(0.75rem, 1.6vh, 1rem);
+        width: 100%;
+        text-align: center;
+        display: block;
+      }
+
+      .rpm, .speed {
+        font-size: clamp(1.6rem, 3.5vh, 2.8rem);
+        color: #fff;
+        font-weight: 700;
+        transition: color 0.15s;
+      }
+
+      .gear {
+        font-size: clamp(3rem, 7vh, 6rem);
+        font-weight: 900;
+        text-align: center;
+        color: #fff;
+        text-shadow: 0 0 2vh rgb(255 255 255 / 15%);
+        line-height: 1.1;
+      }
+    }
+  }
+
+  /* ─── Right fuel panel ─── */
+  .fuel-panel {
+    justify-content: center;
+
+    .fuel-primary {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      padding: 0.4vh 0;
+
+      > span {
+        font-size: clamp(1.4rem, 3vh, 2.2rem);
+        font-weight: 700;
+        color: #fff;
+
+        small {
+          font-size: 0.55em;
+          font-weight: 400;
+          color: var(--label-color);
+          margin-left: 0.2em;
+        }
+      }
+    }
+
+    .info-row {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0.15vh 0;
+
+      > span {
+        font-size: clamp(0.9rem, 1.8vh, 1.2rem);
+        color: #fff;
+      }
+    }
+  }
+
+
+
+  /* ─── Telemetry trace ─── */
+  app-telemetry-trace {
+    min-height: 60px;
+  }
+
+  /* ─── Pit limiter overlay ─── */
   .pit-limiter {
     position: absolute;
-    top: 20%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    background-color: orange;
-    font-size: clamp(2rem, 6vh, 4rem);
-    color: black;
-    padding: 0.5vh 3vh;
-    border-radius: 1.2vh;
-    animation: text-blinker 2s step-end infinite;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgb(0 0 0 / 60%);
+    color: #ff9800;
+    font-size: clamp(3rem, 8vh, 6rem);
+    font-weight: 900;
+    letter-spacing: 0.15em;
+    animation: pit-pulse 1.2s ease-in-out infinite;
+    z-index: 10;
   }
 
-  .flag {
-    width: 100%;
-    height: 100%;
-    position: relative;
-
-    &.yellow {
-      background-color: yellow;
-    }
-
-    &.green {
-      background-color: green;
-    }
-
-    &.white {
-      background-color: white;
-    }
-
-    &.blue {
-      background-color: blue;
-    }
-
-    &.red {
-      background-color: red;
-    }
-
-    &.black {
-      background-color: black;
-    }
-
-    &.black-orange {
-      background-color: black;
-    }
-
-    &.black-orange::after {
-      content: '';
-      border-radius: 50%;
-      background-color: orange;
-      position: absolute;
-      top: 50%;
-      left: 50%;
-      transform: translate(-50%, -50%);
-      height: 75%;
-      aspect-ratio: 1;
-    }
-
-    &.checkered {
-      width: 100%;
-      height: 100%;
-      background: repeating-conic-gradient(
-        #000 0% 25%,
-        #fff 0% 50%
-      );
-      background-size: 6vh 6vh;
-    }
-
-    &.red-yellow {
-      background-image: repeating-linear-gradient(
-        to right,
-        yellow 0%,
-        yellow 10%,
-        red 10%,
-        red 20%
-      );
-      background-size: 100% 100%;
-    }
-  }
-
-  @keyframes text-blinker {
-    50% {
-      color: transparent;
-    }
-  }
-
-  app-track-positions {
-    width: calc(100% - 1.2vh);
-    margin-left: 0.6vh;
-  }
-
-  app-telemetry-trace {
-    width: calc(100% - 1.2vh);
-    margin-left: 0.6vh;
-    height: 100%;
+  @keyframes pit-pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.35; }
   }
 }

--- a/ClientApp/src/app/displays/race-display/race-display.component.spec.ts
+++ b/ClientApp/src/app/displays/race-display/race-display.component.spec.ts
@@ -75,32 +75,32 @@ describe('Race display component tests', () => {
     it('brake bias is displayed', async () => {
       patchData({ brakeBias: 56.2 });
 
-      expect(await harness.getElementText('#brakeBias')).toEqual('56.2');
+      expect(await harness.getElementText('#brakeBias')).toEqual('56.2%');
     });
 
     it('brake bias without decimal places is displayed with one decimal place', async () => {
       patchData({ brakeBias: 56 });
 
-      expect(await harness.getElementText('#brakeBias')).toEqual('56.0');
+      expect(await harness.getElementText('#brakeBias')).toEqual('56.0%');
     });
 
     it('brake bias with 2 decimal places is displayed with one decimal place', async () => {
       patchData({ brakeBias: 56.28 });
 
-      expect(await harness.getElementText('#brakeBias')).toEqual('56.3');
+      expect(await harness.getElementText('#brakeBias')).toEqual('56.3%');
     });
   });
 
   it('Air temp is displayed', async () => {
     patchData({ airTemp: 25.3 });
 
-    expect(await harness.getElementText('#air-temp')).toEqual('25.3 °C');
+    expect(await harness.getElementText('#air-temp')).toEqual('25.3°');
   });
 
   it('Track temp are displayed', async () => {
     patchData({ trackTemp: 32 });
 
-    expect(await harness.getElementText('#track-temp')).toEqual('32.0 °C');
+    expect(await harness.getElementText('#track-temp')).toEqual('32.0°');
   });
 
   describe('Last laptime tests', () => {
@@ -136,7 +136,7 @@ describe('Race display component tests', () => {
   it('Position is displayed', async () => {
     patchData({ position: 3 });
 
-    expect(await harness.getElementText('#position')).toEqual('3');
+    expect(await harness.getElementText('#position')).toEqual('P3');
   });
 
   it('Position is hidden when not provided by the sim', async () => {
@@ -169,7 +169,7 @@ describe('Race display component tests', () => {
   it('Fuel remaining is displayed', async () => {
     patchData({ fuelRemaining: 14.2 });
 
-    expect(await harness.getElementText('#fuelRemaining')).toEqual('14.2 L');
+    expect(await harness.getElementText('#fuelRemaining')).toEqual('14.2L');
   });
 
   describe('Fuel estimated laps warning', () => {
@@ -177,42 +177,42 @@ describe('Race display component tests', () => {
       // totalLaps - currentLap = 5, fuelEstLaps = 3 -> remaining laps (5) > est (3)
       patchData({ currentLap: 2, totalLaps: 7, fuelEstLaps: 3 });
 
-      expect(await harness.elementHasClass('#fuelEstLaps', 'text-red')).toBe(true);
+      expect(await harness.elementHasClass('#fuelEstLaps', 'text-danger')).toBe(true);
     });
 
     it('Does not show red when estimated laps covers remaining laps', async () => {
       // totalLaps - currentLap = 3, fuelEstLaps = 4 -> remaining laps (3) <= est (4)
       patchData({ currentLap: 2, totalLaps: 5, fuelEstLaps: 4 });
 
-      expect(await harness.elementHasClass('#fuelEstLaps', 'text-red')).toBe(false);
+      expect(await harness.elementHasClass('#fuelEstLaps', 'text-danger')).toBe(false);
     });
   });
 
   describe('Best lap delta time', () => {
     it('Delta time is displayed', async () => {
-      patchData({ bestLapTimeDelta: 0.231 });
+      patchData({ bestLapTime: 92.876, bestLapTimeDelta: 0.231 });
 
       expect(await harness.getElementText('#bestLapTimeDelta')).toEqual('+0.231');
     });
 
-    it('Delta time is not green and not red when 0', async () => {
-      patchData({ bestLapTimeDelta: 0 });
+    it('Delta time is not positive and not negative when 0', async () => {
+      patchData({ bestLapTime: 92.876, bestLapTimeDelta: 0 });
 
-      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-green')).toBe(false);
-      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-red')).toBe(false);
+      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-positive')).toBe(false);
+      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-negative')).toBe(false);
 
     });
 
-    it('Delta time is red when > 0', async () => {
-      patchData({ bestLapTimeDelta: 0.234 });
+    it('Delta time is negative when > 0', async () => {
+      patchData({ bestLapTime: 92.876, bestLapTimeDelta: 0.234 });
 
-      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-red')).toBe(true);
+      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-negative')).toBe(true);
     });
 
-    it('Delta time is green when < 0', async () => {
-      patchData({ bestLapTimeDelta: -0.234 });
+    it('Delta time is positive when < 0', async () => {
+      patchData({ bestLapTime: 92.876, bestLapTimeDelta: -0.234 });
 
-      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-green')).toBe(true);
+      expect(await harness.elementHasClass('#bestLapTimeDelta', 'text-positive')).toBe(true);
     });
   });
 

--- a/ClientApp/src/app/displays/race-display/telemetry-trace.component.scss
+++ b/ClientApp/src/app/displays/race-display/telemetry-trace.component.scss
@@ -1,13 +1,13 @@
 .chart-container {
   height: 100%;
+  border-radius: 0.8vh;
+  overflow: hidden;
 }
 
 canvas {
   display: block;
-  margin: auto;
   width: 100%;
   height: 100%;
-  background-color: black;
-  padding: 0.5vh;
+  background: rgb(0 0 0 / 40%);
   box-sizing: border-box;
 }

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.harness.ts
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.harness.ts
@@ -4,12 +4,12 @@ export class RallyDisplayComponentHarness extends ComponentHarness {
   public static hostSelector = 'app-rally-display';
 
   public async getCompletedText(): Promise<string> {
-    const element = await this.locatorFor(':contains("Completed")')();
+    const element = await this.locatorFor(':contains("Stage Progress")')();
     return element.text();
   }
 
   public async getTravelledText(): Promise<string> {
-    const element = await this.locatorFor(':contains("Travelled")')();
+    const element = await this.locatorFor(':contains("Distance")')();
     return element.text();
   }
 
@@ -24,7 +24,7 @@ export class RallyDisplayComponentHarness extends ComponentHarness {
   }
 
   public async hasMaxRpmClass(): Promise<boolean> {
-    const element = await this.locatorFor('.speedometer')();
+    const element = await this.locatorFor('.speedometer-section')();
     return element.hasClass('max-rpm');
   }
 }

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.html
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.html
@@ -1,33 +1,38 @@
 <div class="container">
-  <div class="group-border border-blue">
-    <div class="sectors-row">
-      <div class="sector-item">
-        <label>Completed</label>
-        <div>{{data().completedPct}} %</div>
-      </div>
-      <div class="sector-item">
-        <label>Travelled</label>
-        <div>{{data().distanceTravelled}} m</div>
-      </div>
+  <!-- Progress Section -->
+  <div class="progress-section">
+    <div class="progress-header">
+      <label>Stage Progress</label>
+      <span class="completion-percentage">{{data().completedPct}}%</span>
+    </div>
+    <div class="progress-bar-container">
+      <div class="progress-bar" [style.width.%]="data().completedPct"></div>
+      <div class="progress-bar-glow"></div>
+    </div>
+    <div class="distance-info">
+      <span class="label">Distance</span>
+      <span class="value">{{data().distanceTravelled}} m</span>
     </div>
   </div>
-  <div class="group-border border-yellow speedometer" [class.max-rpm]="data().rpm >= data().rpmMax">
+
+  <!-- Speedometer Section -->
+  <div class="speedometer-section" [class.max-rpm]="data().rpm >= data().rpmMax">
     <app-speedometer [rpm]="data().rpm" [gear]="data().gear" [speed]="data().speed" />
   </div>
-  <div class="group-border border-blue">
-    <div class="sectors-row">
-      <div class="sector-item">
-        <label>Sector 1</label>
-        <div>{{data().sector1Time | laptime}}</div>
-      </div>
-      <div class="sector-item">
-        <label>Sector 2</label>
-        <div>{{data().sector2Time | laptime}}</div>
-      </div>
-      <div class="sector-item">
-        <label>Stage running</label>
-        <div>{{data().lapTime | laptime}}</div>
-      </div>
+
+  <!-- Sectors Section -->
+  <div class="sectors-section">
+    <div class="sector-card">
+      <label>Sector 1</label>
+      <div class="sector-time">{{data().sector1Time | laptime}}</div>
+    </div>
+    <div class="sector-card">
+      <label>Sector 2</label>
+      <div class="sector-time">{{data().sector2Time | laptime}}</div>
+    </div>
+    <div class="sector-card stage-running">
+      <label>Stage Running</label>
+      <div class="sector-time">{{data().lapTime | laptime}}</div>
     </div>
   </div>
 </div>

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.scss
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.scss
@@ -1,6 +1,7 @@
 app-rally-display {
   height: 100%;
   padding-top: 2vh;
+  box-sizing: border-box;
 
   .container {
     max-width: unset;
@@ -11,6 +12,8 @@ app-rally-display {
     gap: 1.6vh;
     padding: 0 2vw;
     height: 100%;
+    overflow: hidden;
+    box-sizing: border-box;
   }
 
   /* Progress Section */
@@ -21,6 +24,7 @@ app-rally-display {
     padding: 2vh 2.5vh;
     backdrop-filter: blur(10px);
     animation: slide-in-down 0.6s ease-out;
+    flex: 0 0 auto;
 
     .progress-header {
       display: flex;
@@ -98,21 +102,20 @@ app-rally-display {
     background: linear-gradient(135deg, rgb(255 200 0 / 8%) 0%, rgb(255 100 0 / 5%) 100%);
     border: 2px solid rgb(255 215 0 / 40%);
     border-radius: 1.5vh;
-    padding: 1.2vh 2.5vh;
-    flex: 0 0 28vh;
+    padding: 0.5vh 2.5vh;
+    flex: 0 0 32vh;
     display: flex;
     flex-direction: column;
     justify-content: center;
     align-items: center;
     backdrop-filter: blur(10px);
-    animation: slide-in-up 0.6s ease-out;
-    transition: all 0.3s ease;
+    will-change: auto;
+    box-sizing: border-box;
 
     &.max-rpm {
       background: linear-gradient(135deg, rgb(255 0 0 / 15%) 0%, rgb(255 100 0 / 10%) 100%);
       border-color: rgb(255 0 0 / 80%);
       box-shadow: 0 0 30px rgb(255 0 0 / 40%), inset 0 0 30px rgb(255 0 0 / 10%);
-      animation: max-rpm-warning 0.5s ease-in-out infinite;
 
       app-speedometer {
         > label {
@@ -138,14 +141,14 @@ app-rally-display {
 
       .rpm, .speed {
         font-size: clamp(2.6rem, 6vh, 5rem);
-        color: #ffffff;
+        color: #fff;
         font-weight: 700;
         text-shadow: 0 0 20px rgb(255 255 255 / 20%);
       }
 
       .gear {
         font-size: clamp(5rem, 12vh, 10rem);
-        color: #ffffff;
+        color: #fff;
         text-align: center;
         font-weight: 900;
         text-shadow: 0 0 30px rgb(255 255 255 / 20%);
@@ -160,6 +163,10 @@ app-rally-display {
     grid-template-columns: repeat(3, 1fr);
     gap: 1.8vh;
     animation: slide-in-up 0.8s ease-out;
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden;
+    padding-bottom: 2vh;
 
     .sector-card {
       background: linear-gradient(135deg, rgb(100 50 255 / 10%) 0%, rgb(50 100 255 / 5%) 100%);

--- a/ClientApp/src/app/displays/rally-display/rally-display.component.scss
+++ b/ClientApp/src/app/displays/rally-display/rally-display.component.scss
@@ -1,74 +1,288 @@
 app-rally-display {
   height: 100%;
-  padding-top: 4vh;
+  padding-top: 2vh;
 
   .container {
     max-width: unset;
     color: white;
     font-size: clamp(1.4rem, 3.5vh, 2.2rem);
-    text-align: center;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1.6vh;
-  }
-
-  .speedometer {
     display: flex;
     flex-direction: column;
+    gap: 1.6vh;
+    padding: 0 2vw;
+    height: 100%;
+  }
 
-    &.max-rpm {
-      background-color: red;
+  /* Progress Section */
+  .progress-section {
+    background: linear-gradient(135deg, rgb(0 150 255 / 10%) 0%, rgb(0 220 255 / 5%) 100%);
+    border: 1px solid rgb(0 220 255 / 40%);
+    border-radius: 1.2vh;
+    padding: 2vh 2.5vh;
+    backdrop-filter: blur(10px);
+    animation: slide-in-down 0.6s ease-out;
+
+    .progress-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin-bottom: 1.5vh;
+
+      label {
+        text-transform: uppercase;
+        font-size: clamp(0.9rem, 1.8vh, 1.2rem);
+        letter-spacing: 1px;
+        color: #6db3d8;
+        font-weight: 600;
+      }
+
+      .completion-percentage {
+        font-size: clamp(1.2rem, 2.5vh, 1.8rem);
+        color: #7dd3c0;
+        font-weight: 700;
+        text-shadow: 0 0 10px rgb(125 211 192 / 30%);
+      }
+    }
+
+    .progress-bar-container {
+      position: relative;
+      width: 100%;
+      height: 3vh;
+      background: rgb(0 0 0 / 30%);
+      border-radius: 1.5vh;
+      overflow: hidden;
+      margin-bottom: 1.5vh;
+      border: 1px solid rgb(0 220 255 / 20%);
+
+      .progress-bar {
+        height: 100%;
+        background: linear-gradient(90deg, #4a90e2 0%, #7dd3c0 50%, #f5a623 100%);
+        border-radius: 1.5vh;
+        transition: width 0.3s ease-out;
+        box-shadow: 0 0 15px rgb(125 211 192 / 40%);
+        animation: progress-pulse 2s ease-in-out infinite;
+      }
+
+      .progress-bar-glow {
+        position: absolute;
+        top: 0;
+        right: 0;
+        width: 20%;
+        height: 100%;
+        background: radial-gradient(circle, rgb(125 211 192 / 30%) 0%, transparent 70%);
+        pointer-events: none;
+      }
+    }
+
+    .distance-info {
+      display: flex;
+      justify-content: space-between;
+      font-size: clamp(0.95rem, 2vh, 1.3rem);
+
+      .label {
+        color: rgb(109 179 216 / 70%);
+        text-transform: uppercase;
+        font-size: clamp(0.85rem, 1.6vh, 1.1rem);
+        letter-spacing: 0.5px;
+      }
+
+      .value {
+        color: #7dd3c0;
+        font-weight: 600;
+      }
     }
   }
 
-  .group-border {
-    border: white 0.3vh solid;
-    padding: 2vh;
-    border-radius: 1.4vh;
+  /* Speedometer Section */
+  .speedometer-section {
+    background: linear-gradient(135deg, rgb(255 200 0 / 8%) 0%, rgb(255 100 0 / 5%) 100%);
+    border: 2px solid rgb(255 215 0 / 40%);
+    border-radius: 1.5vh;
+    padding: 1.2vh 2.5vh;
+    flex: 0 0 28vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+    backdrop-filter: blur(10px);
+    animation: slide-in-up 0.6s ease-out;
+    transition: all 0.3s ease;
 
-    &.border-blue {
-      border-color: rgb(0 0 255 / 55.5%);
-    }
+    &.max-rpm {
+      background: linear-gradient(135deg, rgb(255 0 0 / 15%) 0%, rgb(255 100 0 / 10%) 100%);
+      border-color: rgb(255 0 0 / 80%);
+      box-shadow: 0 0 30px rgb(255 0 0 / 40%), inset 0 0 30px rgb(255 0 0 / 10%);
+      animation: max-rpm-warning 0.5s ease-in-out infinite;
 
-    &.border-yellow {
-      border-color: yellow;
-    }
-
-    label {
-      text-transform: uppercase;
-      font-size: clamp(0.9rem, 2vh, 1.2rem);
-      text-align: right;
-      color: gold;
+      app-speedometer {
+        > label {
+          color: #e94f37;
+          text-shadow: 0 0 20px rgb(233 79 55 / 40%);
+        }
+      }
     }
 
     app-speedometer {
+      text-align: center;
+      width: 100%;
+
       > label {
         text-transform: uppercase;
-        text-align: center;
-        width: 100%;
-        font-size: clamp(1.4rem, 3.5vh, 2.2rem);
-        color: gold;
+        font-size: clamp(1.2rem, 3vh, 1.8rem);
+        color: #f5a623;
+        font-weight: 600;
+        letter-spacing: 2px;
+        margin-bottom: 1.5vh;
+        text-shadow: 0 0 10px rgb(245 166 35 / 30%);
       }
 
       .rpm, .speed {
         font-size: clamp(2.6rem, 6vh, 5rem);
+        color: #ffffff;
+        font-weight: 700;
+        text-shadow: 0 0 20px rgb(255 255 255 / 20%);
       }
 
       .gear {
-        text-align: center;
         font-size: clamp(5rem, 12vh, 10rem);
+        color: #ffffff;
+        text-align: center;
+        font-weight: 900;
+        text-shadow: 0 0 30px rgb(255 255 255 / 20%);
+        margin: 1vh 0;
       }
     }
   }
 
-  .sectors-row {
-    display: flex;
-    justify-content: center;
-    gap: 2vh;
+  /* Sectors Section */
+  .sectors-section {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.8vh;
+    animation: slide-in-up 0.8s ease-out;
+
+    .sector-card {
+      background: linear-gradient(135deg, rgb(100 50 255 / 10%) 0%, rgb(50 100 255 / 5%) 100%);
+      border: 1px solid rgb(100 150 255 / 40%);
+      border-radius: 1.2vh;
+    padding: 1.5vh 1.2vh;
+      text-align: center;
+      backdrop-filter: blur(10px);
+      transition: all 0.3s cubic-bezier(0.34, 1.56, 0.64, 1);
+      cursor: default;
+
+      &:hover {
+        border-color: rgb(100 150 255 / 80%);
+        box-shadow: 0 8px 24px rgb(100 150 255 / 30%);
+        transform: translateY(-4px);
+        background: linear-gradient(135deg, rgb(100 50 255 / 20%) 0%, rgb(50 100 255 / 10%) 100%);
+      }
+
+      label {
+        display: block;
+        text-transform: uppercase;
+        font-size: clamp(0.8rem, 1.6vh, 1.1rem);
+        letter-spacing: 1px;
+        color: #6db3d8;
+        margin-bottom: 0.8vh;
+        font-weight: 600;
+      }
+
+      .sector-time {
+        font-size: clamp(1.8rem, 4vh, 3rem);
+        color: #7dd3c0;
+        font-weight: 700;
+        font-variant-numeric: tabular-nums;
+        text-shadow: 0 0 15px rgb(125 211 192 / 25%);
+      }
+
+      &.stage-running {
+        border-color: rgb(245 166 35 / 50%);
+        background: linear-gradient(135deg, rgb(245 166 35 / 10%) 0%, rgb(233 79 55 / 5%) 100%);
+        animation: pulse 2s ease-in-out infinite;
+
+        label {
+          color: #f5a623;
+        }
+
+        .sector-time {
+          color: #f5a623;
+          text-shadow: 0 0 15px rgb(245 166 35 / 30%);
+        }
+
+        &:hover {
+          border-color: rgb(245 166 35 / 80%);
+          box-shadow: 0 8px 24px rgb(245 166 35 / 25%);
+        }
+      }
+    }
   }
 
-  .sector-item {
-    text-align: center;
-    flex: 1;
+  /* Animations */
+  @keyframes slide-in-down {
+    from {
+      opacity: 0;
+      transform: translateY(-20px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes slide-in-up {
+    from {
+      opacity: 0;
+      transform: translateY(20px);
+    }
+
+    to {
+      opacity: 1;
+      transform: translateY(0);
+    }
+  }
+
+  @keyframes pulse {
+    0%, 100% {
+      opacity: 1;
+    }
+
+    50% {
+      opacity: 0.7;
+    }
+  }
+
+  @keyframes progress-pulse {
+    0%, 100% {
+      box-shadow: 0 0 15px rgb(125 211 192 / 40%);
+    }
+
+    50% {
+      box-shadow: 0 0 25px rgb(125 211 192 / 60%);
+    }
+  }
+
+  @keyframes max-rpm-warning {
+    0%, 100% {
+      box-shadow: 0 0 20px rgb(233 79 55 / 30%), inset 0 0 20px rgb(233 79 55 / 5%);
+    }
+
+    50% {
+      box-shadow: 0 0 35px rgb(233 79 55 / 50%), inset 0 0 20px rgb(233 79 55 / 10%);
+    }
+  }
+
+  /* Responsive */
+  @media (aspect-ratio <= 16 / 9) {
+    .container {
+      gap: 1.6vh;
+      padding: 0 1vw;
+    }
+
+    .sectors-section {
+      grid-template-columns: repeat(3, 1fr);
+      gap: 1.4vh;
+    }
   }
 }

--- a/ClientApp/src/app/state/app.store.spec.ts
+++ b/ClientApp/src/app/state/app.store.spec.ts
@@ -118,6 +118,7 @@ describe('MockAppStore', () => {
         fuelAvgLap: 3.1,
         fuelRemaining: 85,
         fuelEstLaps: 25,
+        currentLapTime: 92000,
         lastLapTime: 95000,
         lastLapTimeDelta: -250,
         bestLapTime: 94500,


### PR DESCRIPTION
Reorganized race display layout:

- Moved Safety Rating, SOF, Air/Track temp to top bar
- Moved Pos, Lap, Expected pos to left info panel
- Added Current lap time to info panel
- Changed SR label to Safety Rating, Expected to Expected pos
- Fixed SOF/Safety Rating null check
- Improved lap time alignment with CSS grid
- Fuel and Brake bias now use large left-aligned labels
- Brake bias moved below fuel fields