### PR TITLE
chore(ci): add fortnightly dependency update workflow

### DIFF
--- a/.github/workflows/deps-update.yml
+++ b/.github/workflows/deps-update.yml
@@ -1,0 +1,131 @@
+name: Dependency Update
+
+on:
+  schedule:
+    - cron: '0 6 1,15 * *'  # 1st and 15th of each month at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+env:
+  dotnet_version: '10.0.201'
+  node_version: 24.15.0
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@87b7050bc53ea08284295505d98d2aa94301e852 # v4.2.0
+        with:
+          dotnet-version: ${{ env.dotnet_version }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
+        with:
+          node-version: ${{ env.node_version }}
+
+      - name: Create branch
+        run: |
+          BRANCH="deps/update-$(date +%Y-%m-%d)"
+          git checkout -b "$BRANCH"
+          echo "BRANCH=$BRANCH" >> "$GITHUB_ENV"
+
+      - name: Update .NET dependencies
+        run: |
+          dotnet tool install --global dotnet-outdated-tool
+          dotnet outdated --upgrade
+
+      - name: Update npm dependencies
+        working-directory: ./ClientApp
+        run: |
+          npx npm-check-updates@latest -u 2>/dev/null || true
+          npm install --package-lock-only
+
+      - name: Commit and push
+        run: |
+          git config user.name "haddy-simhub-bot"
+          git config user.email "bot@haddysimhub.dev"
+          git add -A
+          if git diff --staged --quiet; then
+            echo "No dependency updates available"
+            echo "HAS_CHANGES=false" >> "$GITHUB_ENV"
+          else
+            git commit -m "chore(deps): update frontend and backend dependencies"
+            git push origin "$BRANCH"
+            echo "HAS_CHANGES=true" >> "$GITHUB_ENV"
+          fi
+
+      - name: Create Pull Request
+        if: env.HAS_CHANGES == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr create \
+            --title "chore(deps): update dependencies ($(date +%Y-%m-%d))" \
+            --body "Automated fortnightly dependency update.
+
+          This PR updates:
+          - Backend (.NET) NuGet packages to latest versions
+          - Frontend (npm) packages to latest compatible versions
+
+          CI will run automatically; if all checks pass this PR will be merged." \
+            --base main \
+            --head "$BRANCH" \
+            --label "dependencies"
+
+      - name: Wait for CI and merge
+        if: env.HAS_CHANGES == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "Waiting for CI checks on PR branch $BRANCH..."
+
+          for i in $(seq 1 30); do
+            sleep 60
+
+            CHECKS=$(gh pr checks "$BRANCH" --json state,conclusion 2>/dev/null || echo "[]")
+            if [ "$CHECKS" = "[]" ]; then
+              echo "Poll $i/30: no check runs found yet, retrying..."
+              continue
+            fi
+
+            ALL_DONE=true
+            ALL_PASSED=true
+            FAILED_CONCLUSIONS=""
+
+            while IFS=$'\t' read -r state conclusion; do
+              if [ "$state" != "COMPLETED" ]; then
+                ALL_DONE=false
+              fi
+              if [ "$conclusion" = "FAILURE" ] || [ "$conclusion" = "CANCELLED" ] || [ "$conclusion" = "TIMED_OUT" ]; then
+                ALL_PASSED=false
+                FAILED_CONCLUSIONS="$FAILED_CONCLUSIONS $conclusion"
+              fi
+            done < <(echo "$CHECKS" | jq -r '.[] | [.state, .conclusion] | @tsv')
+
+            if $ALL_DONE && $ALL_PASSED; then
+              echo "All CI checks passed. Merging PR..."
+              gh pr merge "$BRANCH" --squash --delete-branch
+              echo "PR merged successfully!"
+              exit 0
+            fi
+
+            if $ALL_DONE && ! $ALL_PASSED; then
+              echo "CI checks failed:$FAILED_CONCLUSIONS"
+              gh pr comment "$BRANCH" --body "⚠️ CI checks failed ($FAILED_CONCLUSIONS). Manual intervention required."
+              exit 1
+            fi
+
+            echo "Poll $i/30: checks still running..."
+          done
+
+          echo "Timed out waiting for CI checks after 30 minutes"
+          gh pr comment "$BRANCH" --body "⏰ Timed out waiting for CI checks (30 min). Manual intervention required."
+          exit 1


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs on the 1st and 15th of each month to:

- Update .NET NuGet packages to latest versions (via `dotnet-outdated`)
- Update npm packages to latest versions (via `npm-check-updates`)
- Create a PR with the changes
- Automatically merge the PR if all CI checks pass

Can also be triggered manually via `workflow_dispatch`.